### PR TITLE
[ANNIE-127]/Add OAuth token storage schema and DB model support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,11 @@ This document is for coding agents working in `auth/`, the AniList OAuth server 
 ## Repository Layout
 
 ```text
+migrations/
+`- <timestamp>_<name>.up.sql    # forward migrations
+`- <timestamp>_<name>.down.sql  # rollback migrations
 src/
-|- main.rs              # App entrypoint, secrets loading, Rocket setup
+|- main.rs              # App entrypoint, secrets loading, Rocket setup, migration runner
 |- routes/
 |  |- login.rs          # /login redirect to AniList OAuth
 |  |- authorized.rs     # /authorized callback and token exchange
@@ -120,10 +123,9 @@ Use the repo root: `cd /Users/sekkensenzai/code/annie-mei/auth`
 
 ### Verification notes
 
-- `cargo fmt --check` currently runs clean.
-- `cargo test -- --list` currently fails because a transitive dependency needs `protoc`.
-- `cargo test -- --list` also fails because `sqlx = 0.6` is missing a runtime feature in `Cargo.toml`.
-- On macOS, installing protobuf is typically `brew install protobuf`.
+- `cargo fmt --check` runs clean.
+- `cargo test` runs clean. DB integration tests require `DATABASE_URL` to be set pointing at a Postgres server where your user has `CREATEDB` privilege. `#[sqlx::test]` creates and drops isolated test databases automatically.
+- Secrets are managed via Doppler; run tests with `doppler run -- cargo test` when working in the configured project.
 
 ## Environment and Secrets
 
@@ -193,7 +195,7 @@ Important notes:
 - The current codebase uses Rocket logging macros such as `info!`; stay consistent unless you are intentionally migrating logging.
 - Log high-level state transitions, not sensitive payloads.
 - Keep Sentry initialization in startup code, not scattered across handlers.
-- There are currently no checked-in unit tests or integration tests; prefer inline unit tests for helpers.
+- Prefer inline unit tests for helpers; use `#[sqlx::test]` for DB repository functions (see `src/utils/functions.rs` for examples).
 - Add `tests/*.rs` integration tests only when route-level or full-flow coverage is needed.
 - For Rocket route testing, prefer Rocket's local client utilities.
 - Keep comments sparse and useful; explain why, not what.
@@ -203,12 +205,11 @@ Important notes:
 - This crate is an auth server for Annie Mei, not the main bot codebase.
 - Changes to OAuth parameters, callback behavior, or token persistence may require matching updates in `../annie-mei`.
 - The sample config files are examples only; they are not guaranteed to match runtime code perfectly.
-- `Cargo.lock` is currently gitignored in this repo.
-- There are no migrations checked into this repo, so schema changes must be coordinated carefully.
+- Migrations live in `migrations/` and run automatically on startup via `sqlx::migrate!()`. Add new migrations as versioned `.up.sql`/`.down.sql` pairs; never edit existing migration files.
 - The most reusable logic currently lives under `src/utils/`; keep additions focused instead of growing one catch-all file.
 
 ## Maintenance Notes
 
 - Update this file when build commands, test layout, or repo conventions change.
-- If you hit the known `protoc` or `sqlx` runtime blockers during verification, mention them in your handoff.
+- The previous `protoc` and `sqlx` runtime feature blockers have been resolved as of ANNIE-136/ANNIE-127.
 - Follow the checked-in code over sample config files when they disagree.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,5 +211,4 @@ Important notes:
 ## Maintenance Notes
 
 - Update this file when build commands, test layout, or repo conventions change.
-- The previous `protoc` and `sqlx` runtime feature blockers have been resolved as of ANNIE-136/ANNIE-127.
 - Follow the checked-in code over sample config files when they disagree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,6 +229,7 @@ name = "annie-mei-auth"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "dotenvy",
  "nanoid",
  "reqwest 0.12.28",
@@ -353,6 +354,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -428,6 +432,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,6 +461,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
@@ -559,11 +581,22 @@ dependencies = [
 
 [[package]]
 name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
- "pem-rfc7468",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -639,6 +672,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -765,6 +799,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -829,6 +874,17 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-intrusive"
@@ -1250,6 +1306,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1524,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1458,6 +1541,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,6 +1556,16 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1642,10 +1741,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1654,6 +1789,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1960,6 +2096,15 @@ dependencies = [
 
 [[package]]
 name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
@@ -1984,6 +2129,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der 0.7.10",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2447,6 +2613,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2764,6 +2950,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2797,6 +2994,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2839,6 +3046,19 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der 0.7.10",
+]
 
 [[package]]
 name = "sqlx"
@@ -2848,7 +3068,9 @@ checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
+ "sqlx-mysql",
  "sqlx-postgres",
+ "sqlx-sqlite",
 ]
 
 [[package]]
@@ -2859,6 +3081,7 @@ checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64",
  "bytes",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -2917,10 +3140,55 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx-core",
+ "sqlx-mysql",
  "sqlx-postgres",
+ "sqlx-sqlite",
  "syn",
  "tokio",
  "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror",
+ "tracing",
+ "whoami",
 ]
 
 [[package]]
@@ -2933,6 +3201,7 @@ dependencies = [
  "base64",
  "bitflags",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -2958,6 +3227,31 @@ dependencies = [
  "thiserror",
  "tracing",
  "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3452,7 +3746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
  "base64",
- "der",
+ "der 0.8.0",
  "log",
  "native-tls",
  "percent-encoding",
@@ -3749,10 +4043,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,8 +26,12 @@ rocket = { version = "0.5.1", features = ["json", "secrets"] }
 sentry = "0.47.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
 sqlx = { version = "0.8.6", default-features = false, features = [
   "postgres",
   "runtime-tokio-rustls",
+  "macros",
+  "migrate",
+  "chrono",
 ] }
 url = "2.5.7"

--- a/migrations/20260328000001_create_oauth_credentials.down.sql
+++ b/migrations/20260328000001_create_oauth_credentials.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_credentials;

--- a/migrations/20260328000001_create_oauth_credentials.up.sql
+++ b/migrations/20260328000001_create_oauth_credentials.up.sql
@@ -8,5 +8,3 @@ CREATE TABLE IF NOT EXISTS oauth_credentials (
     created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT uq_oauth_credentials_anilist_id UNIQUE (anilist_id)
 );
-
-CREATE INDEX IF NOT EXISTS idx_oauth_credentials_anilist_id ON oauth_credentials (anilist_id);

--- a/migrations/20260328000001_create_oauth_credentials.up.sql
+++ b/migrations/20260328000001_create_oauth_credentials.up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS oauth_credentials (
+    discord_user_id    TEXT        PRIMARY KEY,
+    anilist_id         BIGINT      NOT NULL,
+    access_token       TEXT        NOT NULL,
+    refresh_token      TEXT,
+    token_expires_at   TIMESTAMPTZ,
+    token_updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_oauth_credentials_anilist_id UNIQUE (anilist_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_oauth_credentials_anilist_id ON oauth_credentials (anilist_id);

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,11 @@ async fn build_rocket(config: &AppConfig) -> Result<rocket::Rocket<rocket::Build
         .await
         .context("Failed to connect to the database")?;
 
+    sqlx::migrate!("./migrations")
+        .run(&pool)
+        .await
+        .context("Failed to run database migrations")?;
+
     let client = reqwest::Client::builder()
         .user_agent(concat!(
             env!("CARGO_PKG_NAME"),

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -140,8 +140,11 @@ pub fn is_valid_state_token(jar: &CookieJar, state: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use chrono::Duration;
+    use super::{
+        fetch_credential_by_anilist_id, fetch_credential_by_discord_user, upsert_oauth_credentials,
+    };
+    use chrono::{Duration, Utc};
+    use sqlx::{Pool, Postgres};
 
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_inserts_new_credential(pool: Pool<Postgres>) {

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -114,6 +114,30 @@ pub async fn fetch_credential_by_anilist_id(
     .await
 }
 
+pub fn get_state_token() -> String {
+    nanoid!(32)
+}
+
+pub fn is_valid_state_token(jar: &CookieJar, state: &str) -> bool {
+    let state_cookie = jar.get_private("state").or_else(|| {
+        info!("State cookie not found from get_private");
+        jar.get_pending("state")
+    });
+
+    if let Some(state_cookie) = state_cookie {
+        if state_cookie.value() == state {
+            jar.remove_private(("state", ""));
+            return true;
+        }
+
+        info!("State token mismatch");
+    } else {
+        info!("State cookie not found");
+    }
+
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -195,28 +219,4 @@ mod tests {
 
         assert!(result.is_none());
     }
-}
-
-pub fn get_state_token() -> String {
-    nanoid!(32)
-}
-
-pub fn is_valid_state_token(jar: &CookieJar, state: &str) -> bool {
-    let state_cookie = jar.get_private("state").or_else(|| {
-        info!("State cookie not found from get_private");
-        jar.get_pending("state")
-    });
-
-    if let Some(state_cookie) = state_cookie {
-        if state_cookie.value() == state {
-            jar.remove_private(("state", ""));
-            return true;
-        }
-
-        info!("State token mismatch");
-    } else {
-        info!("State cookie not found");
-    }
-
-    false
 }

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -121,9 +121,16 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn upsert_inserts_new_credential(pool: Pool<Postgres>) {
-        upsert_oauth_credentials("111222333444555666", 987654321, "access_tok", Some("refresh_tok"), Some(Utc::now() + Duration::hours(1)), &pool)
-            .await
-            .expect("upsert should succeed");
+        upsert_oauth_credentials(
+            "111222333444555666",
+            987654321,
+            "access_tok",
+            Some("refresh_tok"),
+            Some(Utc::now() + Duration::hours(1)),
+            &pool,
+        )
+        .await
+        .expect("upsert should succeed");
 
         let cred = fetch_credential_by_discord_user("111222333444555666", &pool)
             .await

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -114,6 +114,82 @@ pub async fn fetch_credential_by_anilist_id(
     .await
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_inserts_new_credential(pool: Pool<Postgres>) {
+        upsert_oauth_credentials("111222333444555666", 987654321, "access_tok", Some("refresh_tok"), Some(Utc::now() + Duration::hours(1)), &pool)
+            .await
+            .expect("upsert should succeed");
+
+        let cred = fetch_credential_by_discord_user("111222333444555666", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert_eq!(cred.discord_user_id, "111222333444555666");
+        assert_eq!(cred.anilist_id, 987654321);
+        assert_eq!(cred.access_token, "access_tok");
+        assert_eq!(cred.refresh_token.as_deref(), Some("refresh_tok"));
+        assert!(cred.token_expires_at.is_some());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_updates_existing_credential(pool: Pool<Postgres>) {
+        upsert_oauth_credentials("user1", 111, "old_token", None, None, &pool)
+            .await
+            .expect("first upsert should succeed");
+
+        upsert_oauth_credentials("user1", 111, "new_token", Some("new_refresh"), None, &pool)
+            .await
+            .expect("second upsert should succeed");
+
+        let cred = fetch_credential_by_discord_user("user1", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert_eq!(cred.access_token, "new_token");
+        assert_eq!(cred.refresh_token.as_deref(), Some("new_refresh"));
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn fetch_by_discord_user_returns_none_when_absent(pool: Pool<Postgres>) {
+        let result = fetch_credential_by_discord_user("nonexistent", &pool)
+            .await
+            .expect("fetch should not error");
+
+        assert!(result.is_none());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn fetch_by_anilist_id_finds_correct_credential(pool: Pool<Postgres>) {
+        upsert_oauth_credentials("user_a", 42, "tok_a", None, None, &pool)
+            .await
+            .expect("upsert should succeed");
+
+        let cred = fetch_credential_by_anilist_id(42, &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert_eq!(cred.discord_user_id, "user_a");
+        assert_eq!(cred.anilist_id, 42);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn fetch_by_anilist_id_returns_none_when_absent(pool: Pool<Postgres>) {
+        let result = fetch_credential_by_anilist_id(99999, &pool)
+            .await
+            .expect("fetch should not error");
+
+        assert!(result.is_none());
+    }
+}
+
 pub fn get_state_token() -> String {
     nanoid!(32)
 }

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -1,5 +1,9 @@
-use crate::utils::{consts::ANILIST_USER_BASE, structs::ViewerResponse};
+use crate::utils::{
+    consts::ANILIST_USER_BASE,
+    structs::{OAuthCredential, ViewerResponse},
+};
 
+use chrono::{DateTime, Utc};
 use nanoid::nanoid;
 use rocket::{http::CookieJar, response::status::BadRequest};
 use serde_json::json;
@@ -35,6 +39,8 @@ pub async fn fetch_viewer_id(
     Ok(viewer_response.data.viewer.id)
 }
 
+/// Prototype-era token save; keyed on anilist_id only. Used by the existing /authorized
+/// callback and will be replaced in ANNIE-129 when the full callback is rewritten.
 pub async fn save_access_token(
     access_token: &str,
     anilist_id: i64,
@@ -47,6 +53,65 @@ pub async fn save_access_token(
         .execute(db)
         .await
         .map(|_| ())
+}
+
+/// Upserts AniList OAuth credentials for the given Discord user. On conflict on
+/// `discord_user_id`, updates all token fields and refreshes `token_updated_at`.
+pub async fn upsert_oauth_credentials(
+    discord_user_id: &str,
+    anilist_id: i64,
+    access_token: &str,
+    refresh_token: Option<&str>,
+    token_expires_at: Option<DateTime<Utc>>,
+    db: &Pool<Postgres>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "INSERT INTO oauth_credentials \
+         (discord_user_id, anilist_id, access_token, refresh_token, token_expires_at, token_updated_at) \
+         VALUES ($1, $2, $3, $4, $5, NOW()) \
+         ON CONFLICT (discord_user_id) DO UPDATE SET \
+             anilist_id = EXCLUDED.anilist_id, \
+             access_token = EXCLUDED.access_token, \
+             refresh_token = EXCLUDED.refresh_token, \
+             token_expires_at = EXCLUDED.token_expires_at, \
+             token_updated_at = NOW()",
+    )
+    .bind(discord_user_id)
+    .bind(anilist_id)
+    .bind(access_token)
+    .bind(refresh_token)
+    .bind(token_expires_at)
+    .execute(db)
+    .await
+    .map(|_| ())
+}
+
+pub async fn fetch_credential_by_discord_user(
+    discord_user_id: &str,
+    db: &Pool<Postgres>,
+) -> Result<Option<OAuthCredential>, sqlx::Error> {
+    sqlx::query_as::<_, OAuthCredential>(
+        "SELECT discord_user_id, anilist_id, access_token, refresh_token, \
+         token_expires_at, token_updated_at, created_at \
+         FROM oauth_credentials WHERE discord_user_id = $1",
+    )
+    .bind(discord_user_id)
+    .fetch_optional(db)
+    .await
+}
+
+pub async fn fetch_credential_by_anilist_id(
+    anilist_id: i64,
+    db: &Pool<Postgres>,
+) -> Result<Option<OAuthCredential>, sqlx::Error> {
+    sqlx::query_as::<_, OAuthCredential>(
+        "SELECT discord_user_id, anilist_id, access_token, refresh_token, \
+         token_expires_at, token_updated_at, created_at \
+         FROM oauth_credentials WHERE anilist_id = $1",
+    )
+    .bind(anilist_id)
+    .fetch_optional(db)
+    .await
 }
 
 pub fn get_state_token() -> String {

--- a/src/utils/structs.rs
+++ b/src/utils/structs.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use sqlx::PgPool;
 
@@ -12,6 +13,20 @@ pub struct MyState {
 #[derive(Debug, Deserialize)]
 pub struct TokenResponse {
     pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub expires_in: Option<i64>,
+    pub token_type: Option<String>,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+pub struct OAuthCredential {
+    pub discord_user_id: String,
+    pub anilist_id: i64,
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+    pub token_expires_at: Option<DateTime<Utc>>,
+    pub token_updated_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
 }
 
 #[derive(Deserialize)]
@@ -36,4 +51,34 @@ pub struct StateToken<'r>(pub &'r str);
 pub enum StateTokenError {
     Missing,
     Invalid,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TokenResponse;
+
+    #[test]
+    fn token_response_deserializes_full_payload() {
+        let json = r#"{
+            "access_token": "tok_abc",
+            "refresh_token": "ref_xyz",
+            "expires_in": 3600,
+            "token_type": "Bearer"
+        }"#;
+        let r: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(r.access_token, "tok_abc");
+        assert_eq!(r.refresh_token.as_deref(), Some("ref_xyz"));
+        assert_eq!(r.expires_in, Some(3600));
+        assert_eq!(r.token_type.as_deref(), Some("Bearer"));
+    }
+
+    #[test]
+    fn token_response_deserializes_access_token_only() {
+        let json = r#"{"access_token": "tok_abc"}"#;
+        let r: TokenResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(r.access_token, "tok_abc");
+        assert!(r.refresh_token.is_none());
+        assert!(r.expires_in.is_none());
+        assert!(r.token_type.is_none());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds `oauth_credentials` table migration (up/down) keyed on `discord_user_id` with `anilist_id`, `access_token`, `refresh_token`, `token_expires_at`, `token_updated_at`, and `created_at`
- Adds `OAuthCredential` sqlx `FromRow` model and expands `TokenResponse` to capture `refresh_token`, `expires_in`, and `token_type`
- Adds `upsert_oauth_credentials`, `fetch_credential_by_discord_user`, and `fetch_credential_by_anilist_id` repository functions
- Wires `sqlx::migrate!()` into startup so migrations apply automatically on boot

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes

- e00910bda46c411b8c1623b2dc946aa7bd11c9a9: chore(deps): add chrono, sqlx macros/migrate/chrono features
- 8ed84d385f64a2b827dcba829b03ec36a8a7103f: feat(db): add oauth_credentials migration
- c302ac3a7faa85ea74b355556cee1e492b6f3512: feat(db): add OAuthCredential model and expand TokenResponse
- 4a5c33698375b3a7026e47c32963c7999952b946: feat(db): add upsert and fetch repository functions
- 3237d765e930408b1ad8441c040e1ae54740ae9d: feat(db): run migrations on startup
- 8b0a094353c0cd1bfc1ee7f1b459e30f01bb8a74: test(db): add sqlx integration tests for oauth_credentials repo
- 2c3bccc5355df6534c0ddfdb64d8193cf5dbb312: docs(agents): update AGENTS.md to reflect working test suite and migrations
- ab4cba2358fe664809c5a99b95bdfea9e15886b7: docs(agents): remove resolved-blocker note from maintenance section
- 9370bc3e07cd6ca03d4e6c28ccabc498051fbe87: style(db): apply rustfmt to test call in functions.rs

### Notes

The existing `save_access_token` function (used by the prototype `/authorized` route) is preserved unchanged. It will be removed in ANNIE-129 when the full callback is rewritten per the ANNIE-126 architecture contract.

`discord_user_id` is the authoritative upsert key per the contract. The `anilist_id` unique constraint covers reverse lookups but a conflict on `anilist_id` from a different `discord_user_id` will surface as a DB error — edge case handling is deferred to ANNIE-129.

### High-risk resources

`sqlx::migrate!()` runs on every boot. If the migration fails (e.g. schema drift on a shared DB), startup will hard-fail with a clear error message. Down migration (`DROP TABLE IF EXISTS oauth_credentials`) is safe to run if rollback is needed.

## Validation

- [x] `cargo check` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo test utils::functions` — 5/5 DB integration tests pass against live Postgres (via Doppler)
- [x] Migration up/down reviewed manually

## References

- Linear: ANNIE-127
- Architecture contract: https://www.notion.so/3300c6c7aa8b812e9ca9dda567bae378
- Blocked by: ANNIE-126 (Done)
- Blocks: ANNIE-128, ANNIE-129

---

This PR description was written by Claude Opus 4.6.