### PR TITLE
[ANNIE-137]/Split CI on auth repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
           shared-key: "cargo-clippy"
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Build check
-        run: cargo check
-
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           cache-on-failure: "true"
           prefix-key: "auth"
-          shared-key: "cargo-ci"
+          shared-key: "cargo-clippy"
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build check
@@ -59,7 +59,6 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout
@@ -75,8 +74,10 @@ jobs:
         with:
           cache-on-failure: "true"
           prefix-key: "auth"
-          shared-key: "cargo-ci"
+          shared-key: "cargo-test"
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Test
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
   pull_request:
 
 jobs:
-  rust:
+  fmt:
+    name: Format
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
@@ -19,7 +20,25 @@ jobs:
       - name: Install Rust
         run: |
           toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
-          rustup toolchain install "$toolchain" --profile minimal --component rustfmt --component clippy
+          rustup toolchain install "$toolchain" --profile minimal --component rustfmt
+
+      - name: Format check
+        run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        run: |
+          toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal --component clippy
 
       - name: Cache
         uses: Swatinem/rust-cache@v2.9.1
@@ -29,14 +48,34 @@ jobs:
           shared-key: "cargo-ci"
           save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Format check
-        run: cargo fmt --check
-
       - name: Build check
         run: cargo check
 
       - name: Clippy
         run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        run: |
+          toolchain="$(awk -F'"' '/^[[:space:]]*channel[[:space:]]*=/ { print $2 }' rust-toolchain.toml)"
+          rustup toolchain install "$toolchain" --profile minimal
+
+      - name: Cache
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          cache-on-failure: "true"
+          prefix-key: "auth"
+          shared-key: "cargo-ci"
+          save-if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') }}
 
       - name: Test
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       CARGO_TERM_COLOR: always
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Splits the single sequential `rust` CI job into three parallel jobs so all failures surface simultaneously instead of stopping at the first failing step.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] Chore

## Changes

- c286f5f43c512c55bc082552bafa2793510aa183: Split `rust` job into parallel `fmt`, `clippy`, and `test` jobs; each installs only the Rust components it needs
- 7f674296d7f7c9a2793360487d86b2ad37b40075: [ANNIE-138] Pipe `DATABASE_URL` gh secret into the `test` job to enable `sqlx::test` DB integration tests in CI

### Notes

`fmt` skips the cache step entirely since format checking does not compile any artifacts. Secrets sourced via `${{ secrets.* }}` are automatically masked in GitHub Actions logs.

## Validation

- [x] CI passes on this PR
- [x] Verified `DATABASE_URL` secret is configured in repo settings

## References

Closes ANNIE-137, ANNIE-138

---

This PR description was written by claude-sonnet-4-6.