### PR TITLE
[ANNIE-129]/Complete AniList callback token exchange and persistence in auth service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -251,6 +252,16 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "async-stream"
@@ -575,6 +586,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -858,6 +887,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -909,6 +939,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +970,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1246,6 +1288,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -4270,6 +4313,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,6 @@ sha2 = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry"] }
 url = "2.5.7"
+
+[dev-dependencies]
+wiremock = "0.6.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,10 @@ pub mod utils;
 
 use crate::{
     routes::{authorized::authorized, login::login},
-    utils::structs::MyState,
+    utils::{
+        consts::{ANILIST_TOKEN, ANILIST_USER_BASE},
+        structs::MyState,
+    },
 };
 
 use anyhow::{Context, Result};
@@ -93,6 +96,8 @@ async fn build_rocket(config: &AppConfig) -> Result<rocket::Rocket<rocket::Build
         client_secret: config.client_secret.clone(),
         redirect_uri: config.redirect_uri.clone(),
         bot_auth_secret: config.bot_auth_secret.clone(),
+        token_endpoint: ANILIST_TOKEN.to_string(),
+        user_endpoint: ANILIST_USER_BASE.to_string(),
         client,
         pool,
     };

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -1,20 +1,26 @@
 use crate::utils::{
-    consts::ANILIST_TOKEN,
-    functions::{fetch_viewer_id, upsert_oauth_credentials},
-    structs::{MyState, StateToken, TokenResponse},
+    functions::{
+        exchange_code_for_token, fetch_viewer_id, token_expires_at, upsert_oauth_credentials,
+    },
+    structs::{CallbackResponse, MyState, StateToken},
 };
 
-use chrono::{Duration, Utc};
-use rocket::{State, response::status::BadRequest};
-use serde_json::json;
+use rocket::{
+    State,
+    http::Status,
+    response::{status, status::Custom},
+    serde::json::Json,
+};
 
-#[get("/authorized?<code>")]
+#[get("/authorized?<code>&<error>&<error_description>")]
 #[tracing::instrument(name = "authorized", skip_all, fields(discord_user_id))]
 pub async fn authorized(
-    code: String,
+    code: Option<&str>,
+    error: Option<&str>,
+    error_description: Option<&str>,
     state_token: StateToken,
     state: &State<MyState>,
-) -> Result<String, BadRequest<String>> {
+) -> Custom<Json<CallbackResponse>> {
     tracing::Span::current().record("discord_user_id", state_token.0.as_str());
     info!("State token validated; beginning token exchange");
 
@@ -25,55 +31,98 @@ pub async fn authorized(
         }));
     });
 
-    let response = state
-        .client
-        .post(ANILIST_TOKEN)
-        .json(&json!({
-            "grant_type": "authorization_code",
-            "client_id": state.client_id.as_str(),
-            "client_secret": state.client_secret.as_str(),
-            "redirect_uri": state.redirect_uri.as_str(),
-            "code": code,
-        }))
-        .send()
-        .await
-        .map_err(|e| {
-            sentry::capture_error(&e);
-            BadRequest(format!("AniList token exchange failed: {e}"))
-        })?
-        .error_for_status()
-        .map_err(|e| {
-            sentry::capture_error(&e);
-            BadRequest(format!("AniList token exchange failed: {e}"))
-        })?;
+    if let Some(error_code) = error {
+        let message = match error_code {
+            "access_denied" => "Authorization was denied on AniList. Please try again.",
+            _ => "AniList authorization failed. Please try again.",
+        };
 
-    let token_response = response.json::<TokenResponse>().await.map_err(|e| {
-        sentry::capture_error(&e);
-        BadRequest(format!("Failed to parse AniList token response: {e}"))
-    })?;
+        return callback_error(
+            "oauth_error",
+            error_description.unwrap_or(message),
+            Status::BadRequest,
+        );
+    }
 
-    let token_expires_at = token_response
-        .expires_in
-        .map(|secs| Utc::now() + Duration::seconds(secs));
+    let Some(code) = code else {
+        return callback_error(
+            "missing_code",
+            "Authorization code is missing from the callback.",
+            Status::BadRequest,
+        );
+    };
+
+    let token_response = match exchange_code_for_token(
+        &state.client,
+        state.client_id.as_str(),
+        state.client_secret.as_str(),
+        state.redirect_uri.as_str(),
+        code,
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => {
+            return callback_error(
+                "token_exchange_failed",
+                error.0.as_str(),
+                Status::BadRequest,
+            );
+        }
+    };
+
+    let token_expires_at = token_expires_at(token_response.expires_in);
 
     info!("Fetching User data ...");
-    let user_id = fetch_viewer_id(&state.client, &token_response.access_token).await?;
+    let anilist_id = match fetch_viewer_id(&state.client, &token_response.access_token).await {
+        Ok(user_id) => user_id,
+        Err(error) => {
+            return callback_error("viewer_fetch_failed", error.0.as_str(), Status::BadGateway);
+        }
+    };
     info!("User data fetched successfully");
 
-    upsert_oauth_credentials(
+    if let Err(error) = upsert_oauth_credentials(
         &state_token.0,
-        user_id,
+        anilist_id,
         &token_response.access_token,
         token_response.refresh_token.as_deref(),
         token_expires_at,
         &state.pool,
     )
     .await
-    .map_err(|e| {
-        sentry::capture_error(&e);
-        BadRequest(format!("Failed to save OAuth credentials: {e}"))
-    })?;
+    {
+        sentry::capture_error(&error);
+        error!("Failed to persist AniList credentials: {error}");
+        return callback_error(
+            "persistence_failed",
+            "Failed to save AniList credentials. Please retry.",
+            Status::InternalServerError,
+        );
+    }
 
     info!("Saved OAuth credentials for Discord user");
-    Ok("Success".to_string())
+    callback_success("authorized", "AniList account connected successfully.")
+}
+
+fn callback_success(code: &str, message: &str) -> Custom<Json<CallbackResponse>> {
+    status::Custom(
+        Status::Ok,
+        Json(CallbackResponse {
+            status: "success".to_string(),
+            code: code.to_string(),
+            message: message.to_string(),
+        }),
+    )
+}
+
+fn callback_error(code: &str, message: &str, status: Status) -> Custom<Json<CallbackResponse>> {
+    status::Custom(
+        status,
+        Json(CallbackResponse {
+            status: "error".to_string(),
+            code: code.to_string(),
+            message: message.to_string(),
+        }),
+    )
 }

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -107,6 +107,7 @@ pub async fn authorized(
                 Status::BadRequest,
             ),
             UpsertOAuthCredentialsError::Db(error) => {
+                sentry::capture_error(&error);
                 error!("Failed to persist AniList credentials: {error}");
                 callback_error(
                     "persistence_failed",

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -414,6 +414,50 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_token_parse_failure_returns_user_safe_message(pool: Pool<Postgres>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "token_type": "Bearer"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=bad_payload"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "token_exchange_failed");
+        assert_eq!(
+            callback.message,
+            "Failed to parse AniList token response. Please try again."
+        );
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
     async fn authorized_handles_access_denied_callback(pool: Pool<Postgres>) {
         let client = Client::tracked(build_test_rocket(
             pool.clone(),
@@ -441,6 +485,66 @@ mod tests {
         assert_eq!(callback.status, "error");
         assert_eq!(callback.code, "oauth_error");
         assert_eq!(callback.message, "Denied by user");
+
+        let persisted = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error");
+        assert!(persisted.is_none());
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_viewer_parse_failure_returns_user_safe_message(pool: Pool<Postgres>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access_1",
+                "refresh_token": "refresh_1",
+                "expires_in": 3600,
+                "token_type": "Bearer"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": {}
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=auth_code_1"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadGateway);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "viewer_fetch_failed");
+        assert_eq!(
+            callback.message,
+            "Failed to parse AniList viewer response. Please try again."
+        );
 
         let persisted = fetch_credential_by_discord_user("555666777888", &pool)
             .await

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -38,7 +38,10 @@ pub async fn authorized(
     });
 
     if let Some(error_code) = error {
-        let _ = error_description;
+        info!(
+            "AniList callback returned an OAuth error: {error_code} ({})",
+            error_description.unwrap_or("<missing>")
+        );
         let message = match error_code {
             "access_denied" => "Authorization was denied on AniList. Please try again.",
             _ => "AniList authorization failed. Please try again.",
@@ -83,7 +86,7 @@ pub async fn authorized(
     {
         Ok(user_id) => user_id,
         Err(error) => {
-            return callback_error("viewer_fetch_failed", error.0.as_str(), Status::BadGateway);
+            return callback_error("viewer_fetch_failed", error.message(), error.status());
         }
     };
     info!("User data fetched successfully");
@@ -106,7 +109,7 @@ pub async fn authorized(
             ),
             UpsertOAuthCredentialsError::Db(error) => {
                 sentry::capture_error(&error);
-                error!("Failed to persist AniList credentials: {error}");
+                error!("Failed to persist AniList credentials");
                 callback_error(
                     "persistence_failed",
                     "Failed to save AniList credentials. Please retry.",

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -38,16 +38,13 @@ pub async fn authorized(
     });
 
     if let Some(error_code) = error {
+        let _ = error_description;
         let message = match error_code {
             "access_denied" => "Authorization was denied on AniList. Please try again.",
             _ => "AniList authorization failed. Please try again.",
         };
 
-        return callback_error(
-            "oauth_error",
-            error_description.unwrap_or(message),
-            Status::BadRequest,
-        );
+        return callback_error("oauth_error", message, Status::BadRequest);
     }
 
     let Some(code) = code else {
@@ -70,11 +67,7 @@ pub async fn authorized(
     {
         Ok(response) => response,
         Err(error) => {
-            return callback_error(
-                "token_exchange_failed",
-                error.0.as_str(),
-                Status::BadRequest,
-            );
+            return callback_error("token_exchange_failed", error.message(), error.status());
         }
     };
 
@@ -390,7 +383,7 @@ mod tests {
             .dispatch()
             .await;
 
-        assert_eq!(response.status(), Status::BadRequest);
+        assert_eq!(response.status(), Status::BadGateway);
         let body = response
             .into_string()
             .await
@@ -439,7 +432,7 @@ mod tests {
             .dispatch()
             .await;
 
-        assert_eq!(response.status(), Status::BadRequest);
+        assert_eq!(response.status(), Status::BadGateway);
         let body = response
             .into_string()
             .await
@@ -484,7 +477,10 @@ mod tests {
             serde_json::from_str(body.as_str()).expect("callback response should deserialize");
         assert_eq!(callback.status, "error");
         assert_eq!(callback.code, "oauth_error");
-        assert_eq!(callback.message, "Denied by user");
+        assert_eq!(
+            callback.message,
+            "Authorization was denied on AniList. Please try again."
+        );
 
         let persisted = fetch_credential_by_discord_user("555666777888", &pool)
             .await

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -3,7 +3,7 @@ use crate::utils::{
         UpsertOAuthCredentialsError, exchange_code_for_token, fetch_viewer_id, token_expires_at,
         upsert_oauth_credentials,
     },
-    structs::{CallbackResponse, MyState, StateToken},
+    structs::{CallbackResponse, MyState, StateToken, StateTokenError},
 };
 
 use rocket::{
@@ -19,9 +19,14 @@ pub async fn authorized(
     code: Option<&str>,
     error: Option<&str>,
     error_description: Option<&str>,
-    state_token: StateToken,
+    state_token: Result<StateToken, StateTokenError>,
     state: &State<MyState>,
 ) -> Custom<Json<CallbackResponse>> {
+    let state_token = match state_token {
+        Ok(state_token) => state_token,
+        Err(error) => return callback_error_for_state_token(error),
+    };
+
     tracing::Span::current().record("discord_user_id", state_token.0.as_str());
     info!("State token validated; beginning token exchange");
 
@@ -142,6 +147,36 @@ fn callback_error(code: &str, message: &str, status: Status) -> Custom<Json<Call
             message: message.to_string(),
         }),
     )
+}
+
+fn callback_error_for_state_token(error: StateTokenError) -> Custom<Json<CallbackResponse>> {
+    match error {
+        StateTokenError::Missing => callback_error(
+            "missing_state",
+            "State parameter is missing from the callback.",
+            Status::BadRequest,
+        ),
+        StateTokenError::Invalid => callback_error(
+            "invalid_state",
+            "State parameter is invalid. Please restart the AniList login flow.",
+            Status::BadRequest,
+        ),
+        StateTokenError::Expired => callback_error(
+            "expired_state",
+            "State parameter has expired. Please restart the AniList login flow.",
+            Status::BadRequest,
+        ),
+        StateTokenError::Replayed => callback_error(
+            "replayed_state",
+            "This login link has already been used. Please restart the AniList login flow.",
+            Status::BadRequest,
+        ),
+        StateTokenError::Internal => callback_error(
+            "state_validation_failed",
+            "Failed to validate the AniList login state. Please retry.",
+            Status::InternalServerError,
+        ),
+    }
 }
 
 #[cfg(test)]
@@ -330,6 +365,55 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_upstream_server_error_returns_user_safe_message(pool: Pool<Postgres>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "error": "server_error"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=server_error_code"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "token_exchange_failed");
+        assert_eq!(
+            callback.message,
+            "AniList is temporarily unavailable. Please try again."
+        );
+
+        let persisted = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error");
+        assert!(persisted.is_none());
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
     async fn authorized_handles_access_denied_callback(pool: Pool<Postgres>) {
         let client = Client::tracked(build_test_rocket(
             pool.clone(),
@@ -362,6 +446,75 @@ mod tests {
             .await
             .expect("fetch should not error");
         assert!(persisted.is_none());
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_invalid_state_returns_structured_json(pool: Pool<Postgres>) {
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            "https://anilist.co/api/v2/oauth/token".to_string(),
+            "https://graphql.anilist.co".to_string(),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let response = client
+            .get("/authorized?state=invalid_state&code=auth_code_1")
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "invalid_state");
+        assert!(callback.message.contains("Please restart"));
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_replayed_state_returns_structured_json(pool: Pool<Postgres>) {
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            "https://anilist.co/api/v2/oauth/token".to_string(),
+            "https://graphql.anilist.co".to_string(),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let first_response = client
+            .get(format!(
+                "/authorized?state={state}&error=access_denied&error_description=Denied%20by%20user"
+            ))
+            .dispatch()
+            .await;
+        assert_eq!(first_response.status(), Status::BadRequest);
+        drop(first_response);
+
+        let replay_response = client
+            .get(format!("/authorized?state={state}&code=auth_code_1"))
+            .dispatch()
+            .await;
+
+        assert_eq!(replay_response.status(), Status::BadRequest);
+        let body = replay_response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "replayed_state");
 
         drop(client);
         pool.close().await;

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -1,6 +1,7 @@
 use crate::utils::{
     functions::{
-        exchange_code_for_token, fetch_viewer_id, token_expires_at, upsert_oauth_credentials,
+        UpsertOAuthCredentialsError, exchange_code_for_token, fetch_viewer_id, token_expires_at,
+        upsert_oauth_credentials,
     },
     structs::{CallbackResponse, MyState, StateToken},
 };
@@ -54,6 +55,7 @@ pub async fn authorized(
 
     let token_response = match exchange_code_for_token(
         &state.client,
+        state.token_endpoint.as_str(),
         state.client_id.as_str(),
         state.client_secret.as_str(),
         state.redirect_uri.as_str(),
@@ -74,7 +76,13 @@ pub async fn authorized(
     let token_expires_at = token_expires_at(token_response.expires_in);
 
     info!("Fetching User data ...");
-    let anilist_id = match fetch_viewer_id(&state.client, &token_response.access_token).await {
+    let anilist_id = match fetch_viewer_id(
+        &state.client,
+        state.user_endpoint.as_str(),
+        &token_response.access_token,
+    )
+    .await
+    {
         Ok(user_id) => user_id,
         Err(error) => {
             return callback_error("viewer_fetch_failed", error.0.as_str(), Status::BadGateway);
@@ -92,13 +100,21 @@ pub async fn authorized(
     )
     .await
     {
-        sentry::capture_error(&error);
-        error!("Failed to persist AniList credentials: {error}");
-        return callback_error(
-            "persistence_failed",
-            "Failed to save AniList credentials. Please retry.",
-            Status::InternalServerError,
-        );
+        return match error {
+            UpsertOAuthCredentialsError::AlreadyLinked => callback_error(
+                "already_linked",
+                "This AniList account is already linked to another Discord user.",
+                Status::BadRequest,
+            ),
+            UpsertOAuthCredentialsError::Db(error) => {
+                error!("Failed to persist AniList credentials: {error}");
+                callback_error(
+                    "persistence_failed",
+                    "Failed to save AniList credentials. Please retry.",
+                    Status::InternalServerError,
+                )
+            }
+        };
     }
 
     info!("Saved OAuth credentials for Discord user");
@@ -133,16 +149,35 @@ mod tests {
     use crate::{
         routes::login::login,
         utils::{
-            functions::fetch_credential_by_discord_user,
+            functions::{fetch_credential_by_discord_user, upsert_oauth_credentials},
             structs::{CallbackResponse, MyState},
         },
     };
+    use chrono::Utc;
+    use hmac::{Hmac, Mac};
     use rocket::{Config, http::Status, local::asynchronous::Client, routes};
+    use sha2::Sha256;
     use sqlx::{Pool, Postgres};
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
         matchers::{method, path},
     };
+
+    const TEST_BOT_SECRET: &str = "test-bot-auth-secret-for-unit-tests";
+
+    fn sign_login(discord_user_id: &str, ts: i64) -> String {
+        type HmacSha256 = Hmac<Sha256>;
+        let message = format!("{discord_user_id}:{ts}");
+        let mut mac = HmacSha256::new_from_slice(TEST_BOT_SECRET.as_bytes()).expect("HMAC key");
+        mac.update(message.as_bytes());
+        hex::encode(mac.finalize().into_bytes())
+    }
+
+    fn signed_login_url(discord_user_id: &str) -> String {
+        let ts = Utc::now().timestamp();
+        let sig = sign_login(discord_user_id, ts);
+        format!("/login?discord_user_id={discord_user_id}&ts={ts}&sig={sig}")
+    }
 
     fn build_test_rocket(
         pool: Pool<Postgres>,
@@ -156,6 +191,7 @@ mod tests {
             client_id: "client-id".to_string(),
             client_secret: "client-secret".to_string(),
             redirect_uri: "http://127.0.0.1:8000/authorized".to_string(),
+            bot_auth_secret: TEST_BOT_SECRET.to_string(),
             token_endpoint,
             user_endpoint,
             client: reqwest::Client::new(),
@@ -169,7 +205,7 @@ mod tests {
 
     async fn login_and_extract_state(client: &Client) -> String {
         let response = client
-            .get("/login?discord_user_id=555666777888")
+            .get(signed_login_url("555666777888"))
             .dispatch()
             .await;
         let location = response
@@ -241,6 +277,9 @@ mod tests {
         assert_eq!(persisted.access_token, "access_1");
         assert_eq!(persisted.refresh_token.as_deref(), Some("refresh_1"));
         assert!(persisted.token_expires_at.is_some());
+
+        drop(client);
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -284,6 +323,9 @@ mod tests {
             .await
             .expect("fetch should not error");
         assert!(persisted.is_none());
+
+        drop(client);
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -319,5 +361,76 @@ mod tests {
             .await
             .expect("fetch should not error");
         assert!(persisted.is_none());
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_rejects_anilist_account_linked_to_another_discord_user(
+        pool: Pool<Postgres>,
+    ) {
+        upsert_oauth_credentials("existing_user", 12345, "existing_access", None, None, &pool)
+            .await
+            .expect("seed upsert should succeed");
+
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access_1",
+                "refresh_token": "refresh_1",
+                "expires_in": 3600,
+                "token_type": "Bearer"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "Viewer": { "id": 12345 } }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=auth_code_1"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "already_linked");
+
+        let existing = fetch_credential_by_discord_user("existing_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("existing credential should remain");
+        assert_eq!(existing.access_token, "existing_access");
+
+        let conflicting = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error");
+        assert!(conflicting.is_none());
+
+        drop(client);
+        pool.close().await;
     }
 }

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -126,3 +126,198 @@ fn callback_error(code: &str, message: &str, status: Status) -> Custom<Json<Call
         }),
     )
 }
+
+#[cfg(test)]
+mod tests {
+    use super::authorized;
+    use crate::{
+        routes::login::login,
+        utils::{
+            functions::fetch_credential_by_discord_user,
+            structs::{CallbackResponse, MyState},
+        },
+    };
+    use rocket::{Config, http::Status, local::asynchronous::Client, routes};
+    use sqlx::{Pool, Postgres};
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{method, path},
+    };
+
+    fn build_test_rocket(
+        pool: Pool<Postgres>,
+        token_endpoint: String,
+        user_endpoint: String,
+    ) -> rocket::Rocket<rocket::Build> {
+        let figment =
+            Config::figment().merge(("secret_key", "0123456789abcdef0123456789abcdef0123456789A="));
+
+        let state = MyState {
+            client_id: "client-id".to_string(),
+            client_secret: "client-secret".to_string(),
+            redirect_uri: "http://127.0.0.1:8000/authorized".to_string(),
+            token_endpoint,
+            user_endpoint,
+            client: reqwest::Client::new(),
+            pool,
+        };
+
+        rocket::custom(figment)
+            .mount("/", routes![login, authorized])
+            .manage(state)
+    }
+
+    async fn login_and_extract_state(client: &Client) -> String {
+        let response = client
+            .get("/login?discord_user_id=555666777888")
+            .dispatch()
+            .await;
+        let location = response
+            .headers()
+            .get_one("location")
+            .expect("login should redirect");
+        url::Url::parse(location)
+            .expect("redirect URL should parse")
+            .query_pairs()
+            .find(|(key, _)| key == "state")
+            .map(|(_, value)| value.to_string())
+            .expect("redirect URL should contain state")
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_happy_path_persists_oauth_credentials(pool: Pool<Postgres>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "access_token": "access_1",
+                "refresh_token": "refresh_1",
+                "expires_in": 3600,
+                "token_type": "Bearer"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/graphql"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "data": { "Viewer": { "id": 12345 } }
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=auth_code_1"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "success");
+        assert_eq!(callback.code, "authorized");
+
+        let persisted = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should be persisted");
+
+        assert_eq!(persisted.discord_user_id, "555666777888");
+        assert_eq!(persisted.anilist_id, 12345);
+        assert_eq!(persisted.access_token, "access_1");
+        assert_eq!(persisted.refresh_token.as_deref(), Some("refresh_1"));
+        assert!(persisted.token_expires_at.is_some());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_invalid_grant_returns_friendly_error(pool: Pool<Postgres>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+                "error": "invalid_grant"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=bad_code"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "token_exchange_failed");
+        assert!(callback.message.contains("invalid or expired"));
+
+        let persisted = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error");
+        assert!(persisted.is_none());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_handles_access_denied_callback(pool: Pool<Postgres>) {
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            "https://anilist.co/api/v2/oauth/token".to_string(),
+            "https://graphql.anilist.co".to_string(),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!(
+                "/authorized?state={state}&error=access_denied&error_description=Denied%20by%20user"
+            ))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "oauth_error");
+        assert_eq!(callback.message, "Denied by user");
+
+        let persisted = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error");
+        assert!(persisted.is_none());
+    }
+}

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -358,6 +358,55 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    async fn authorized_invalid_client_returns_bad_gateway(pool: Pool<Postgres>) {
+        let mock_server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/token"))
+            .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+                "error": "invalid_client"
+            })))
+            .mount(&mock_server)
+            .await;
+
+        let client = Client::tracked(build_test_rocket(
+            pool.clone(),
+            format!("{}/token", mock_server.uri()),
+            format!("{}/graphql", mock_server.uri()),
+        ))
+        .await
+        .expect("rocket client should build");
+
+        let state = login_and_extract_state(&client).await;
+        let response = client
+            .get(format!("/authorized?state={state}&code=bad_client"))
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadGateway);
+        let body = response
+            .into_string()
+            .await
+            .expect("response should contain JSON");
+        let callback: CallbackResponse =
+            serde_json::from_str(body.as_str()).expect("callback response should deserialize");
+        assert_eq!(callback.status, "error");
+        assert_eq!(callback.code, "token_exchange_failed");
+        assert_eq!(
+            callback.message,
+            "AniList OAuth client configuration is invalid"
+        );
+
+        let persisted = fetch_credential_by_discord_user("555666777888", &pool)
+            .await
+            .expect("fetch should not error");
+        assert!(persisted.is_none());
+
+        drop(client);
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
     async fn authorized_upstream_server_error_returns_user_safe_message(pool: Pool<Postgres>) {
         let mock_server = MockServer::start().await;
 

--- a/src/routes/login.rs
+++ b/src/routes/login.rs
@@ -88,6 +88,8 @@ mod tests {
             client_secret: "client-secret".to_string(),
             redirect_uri: "http://127.0.0.1:8000/authorized".to_string(),
             bot_auth_secret: TEST_BOT_SECRET.to_string(),
+            token_endpoint: "https://anilist.co/api/v2/oauth/token".to_string(),
+            user_endpoint: "https://graphql.anilist.co".to_string(),
             client: reqwest::Client::new(),
             pool,
         };
@@ -106,6 +108,8 @@ mod tests {
             client_secret: "client-secret".to_string(),
             redirect_uri: "http://127.0.0.1:8000/authorized".to_string(),
             bot_auth_secret: TEST_BOT_SECRET.to_string(),
+            token_endpoint: "https://anilist.co/api/v2/oauth/token".to_string(),
+            user_endpoint: "https://graphql.anilist.co".to_string(),
             client: reqwest::Client::new(),
             pool,
         };

--- a/src/routes/login.rs
+++ b/src/routes/login.rs
@@ -121,7 +121,7 @@ mod tests {
 
     #[sqlx::test(migrations = "./migrations")]
     async fn login_redirects_to_anilist(pool: Pool<Postgres>) {
-        let client = Client::tracked(build_test_rocket(pool))
+        let client = Client::tracked(build_test_rocket(pool.clone()))
             .await
             .expect("rocket client should build");
         let response = client.get(signed_login_url("123456789")).dispatch().await;
@@ -132,11 +132,15 @@ mod tests {
             .get_one("location")
             .expect("login should redirect");
         assert!(location.contains("anilist.co"));
+
+        drop(response);
+        drop(client);
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
     async fn login_rejects_invalid_signature(pool: Pool<Postgres>) {
-        let client = Client::tracked(build_test_rocket(pool))
+        let client = Client::tracked(build_test_rocket(pool.clone()))
             .await
             .expect("rocket client should build");
         let ts = Utc::now().timestamp();
@@ -148,11 +152,15 @@ mod tests {
             .await;
 
         assert_eq!(response.status(), Status::BadRequest);
+
+        drop(response);
+        drop(client);
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
     async fn login_does_not_set_cookies(pool: Pool<Postgres>) {
-        let client = Client::tracked(build_test_rocket(pool))
+        let client = Client::tracked(build_test_rocket(pool.clone()))
             .await
             .expect("rocket client should build");
         let response = client.get(signed_login_url("123456789")).dispatch().await;
@@ -161,11 +169,15 @@ mod tests {
             response.headers().get_one("set-cookie").is_none(),
             "login should not set any cookies"
         );
+
+        drop(response);
+        drop(client);
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
     async fn state_session_is_single_use(pool: Pool<Postgres>) {
-        let client = Client::tracked(build_test_rocket_with_consume(pool))
+        let client = Client::tracked(build_test_rocket_with_consume(pool.clone()))
             .await
             .expect("rocket client should build");
 
@@ -180,6 +192,7 @@ mod tests {
             .find(|(key, _)| key == "state")
             .map(|(_, value)| value.into_owned())
             .expect("redirect URL should include state param");
+        drop(response);
 
         let first = client
             .get(format!("/consume?state={state}"))
@@ -192,6 +205,11 @@ mod tests {
             .dispatch()
             .await;
         assert_eq!(replay.status(), Status::BadRequest);
+
+        drop(first);
+        drop(replay);
+        drop(client);
+        pool.close().await;
     }
 
     #[test]

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -166,9 +166,10 @@ pub async fn exchange_code_for_token(
         _ => "AniList token exchange failed",
     };
 
-    if status.is_server_error()
-        || matches!(error_payload.as_str(), "invalid_client" | "invalid_request")
-    {
+    let is_upstream_failure = status.is_server_error()
+        || matches!(error_payload.as_str(), "invalid_client" | "invalid_request");
+
+    if is_upstream_failure {
         let sentry_message = format!(
             "AniList token exchange returned upstream status {} with payload: {}",
             status.as_u16(),
@@ -178,9 +179,7 @@ pub async fn exchange_code_for_token(
         error!("{sentry_message}");
     }
 
-    if status.is_server_error()
-        || matches!(error_payload.as_str(), "invalid_client" | "invalid_request")
-    {
+    if is_upstream_failure {
         Err(TokenExchangeError::BadGateway(friendly_message.to_string()))
     } else {
         Err(TokenExchangeError::BadRequest(friendly_message.to_string()))

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -153,7 +153,9 @@ pub async fn exchange_code_for_token(
         error!("{sentry_message}");
     }
 
-    if status.is_server_error() {
+    if status.is_server_error()
+        || matches!(error_payload.as_str(), "invalid_client" | "invalid_request")
+    {
         Err(TokenExchangeError::BadGateway(friendly_message.to_string()))
     } else {
         Err(TokenExchangeError::BadRequest(friendly_message.to_string()))

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -1,5 +1,5 @@
 use crate::utils::{
-    consts::{ANILIST_TOKEN, ANILIST_USER_BASE},
+    consts::ANILIST_TOKEN,
     structs::{OAuthCredential, OAuthSession, TokenErrorResponse, TokenResponse, ViewerResponse},
 };
 
@@ -11,9 +11,16 @@ use serde_json::json;
 use sha2::Sha256;
 use sqlx::{Pool, Postgres};
 
+#[derive(Debug)]
+pub enum UpsertOAuthCredentialsError {
+    AlreadyLinked,
+    Db(sqlx::Error),
+}
+
 #[tracing::instrument(skip(client, access_token))]
 pub async fn fetch_viewer_id(
     client: &reqwest::Client,
+    user_endpoint: &str,
     access_token: &str,
 ) -> Result<i64, BadRequest<String>> {
     const USER_QUERY: &str = "
@@ -25,7 +32,7 @@ pub async fn fetch_viewer_id(
     ";
 
     let viewer_response = client
-        .post(ANILIST_USER_BASE)
+        .post(user_endpoint)
         .bearer_auth(access_token)
         .json(&json!({ "query": USER_QUERY }))
         .send()
@@ -53,13 +60,14 @@ pub async fn fetch_viewer_id(
 
 pub async fn exchange_code_for_token(
     client: &reqwest::Client,
+    token_endpoint: &str,
     client_id: &str,
     client_secret: &str,
     redirect_uri: &str,
     code: &str,
 ) -> Result<TokenResponse, BadRequest<String>> {
     let response = client
-        .post(ANILIST_TOKEN)
+        .post(token_endpoint)
         .json(&json!({
             "grant_type": "authorization_code",
             "client_id": client_id,
@@ -121,7 +129,15 @@ pub async fn upsert_oauth_credentials(
     refresh_token: Option<&str>,
     token_expires_at: Option<DateTime<Utc>>,
     db: &Pool<Postgres>,
-) -> Result<(), sqlx::Error> {
+) -> Result<(), UpsertOAuthCredentialsError> {
+    if let Some(existing) = fetch_credential_by_anilist_id(anilist_id, db)
+        .await
+        .map_err(UpsertOAuthCredentialsError::Db)?
+        && existing.discord_user_id != discord_user_id
+    {
+        return Err(UpsertOAuthCredentialsError::AlreadyLinked);
+    }
+
     sqlx::query(
         "INSERT INTO oauth_credentials \
          (discord_user_id, anilist_id, access_token, refresh_token, token_expires_at, token_updated_at) \
@@ -140,7 +156,23 @@ pub async fn upsert_oauth_credentials(
     .bind(token_expires_at)
     .execute(db)
     .await
+    .map_err(|error| {
+        if is_anilist_id_conflict(&error) {
+            UpsertOAuthCredentialsError::AlreadyLinked
+        } else {
+            UpsertOAuthCredentialsError::Db(error)
+        }
+    })
     .map(|_| ())
+}
+
+fn is_anilist_id_conflict(error: &sqlx::Error) -> bool {
+    match error {
+        sqlx::Error::Database(database_error) => {
+            database_error.constraint() == Some("uq_oauth_credentials_anilist_id")
+        }
+        _ => false,
+    }
 }
 
 #[tracing::instrument(skip(db))]
@@ -285,9 +317,9 @@ pub async fn consume_oauth_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        SessionConsumeError, consume_oauth_session, fetch_credential_by_anilist_id,
-        fetch_credential_by_discord_user, insert_oauth_session, token_expires_at,
-        upsert_oauth_credentials, verify_bot_signature,
+        SessionConsumeError, UpsertOAuthCredentialsError, consume_oauth_session,
+        fetch_credential_by_anilist_id, fetch_credential_by_discord_user, insert_oauth_session,
+        token_expires_at, upsert_oauth_credentials, verify_bot_signature,
     };
     use chrono::{Duration, Utc};
     use hmac::{Hmac, Mac};
@@ -364,6 +396,8 @@ mod tests {
         assert_eq!(cred.access_token, "access_tok");
         assert_eq!(cred.refresh_token.as_deref(), Some("refresh_tok"));
         assert!(cred.token_expires_at.is_some());
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -383,6 +417,8 @@ mod tests {
 
         assert_eq!(cred.access_token, "new_token");
         assert_eq!(cred.refresh_token.as_deref(), Some("new_refresh"));
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -392,6 +428,8 @@ mod tests {
             .expect("fetch should not error");
 
         assert!(result.is_none());
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -407,6 +445,8 @@ mod tests {
 
         assert_eq!(cred.discord_user_id, "user_a");
         assert_eq!(cred.anilist_id, 42);
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -416,6 +456,31 @@ mod tests {
             .expect("fetch should not error");
 
         assert!(result.is_none());
+
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn upsert_rejects_anilist_id_linked_to_another_discord_user(pool: Pool<Postgres>) {
+        upsert_oauth_credentials("user_a", 42, "tok_a", None, None, &pool)
+            .await
+            .expect("initial upsert should succeed");
+
+        let error = upsert_oauth_credentials("user_b", 42, "tok_b", None, None, &pool)
+            .await
+            .expect_err("conflicting upsert should fail");
+
+        assert!(matches!(error, UpsertOAuthCredentialsError::AlreadyLinked));
+
+        let credential = fetch_credential_by_anilist_id(42, &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should still exist");
+
+        assert_eq!(credential.discord_user_id, "user_a");
+        assert_eq!(credential.access_token, "tok_a");
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -76,13 +76,16 @@ pub async fn exchange_code_for_token(
         }))
         .send()
         .await
-        .map_err(|_| BadRequest("AniList token exchange request failed".to_string()))?;
+        .map_err(|e| {
+            sentry::capture_error(&e);
+            BadRequest(format!("AniList token exchange request failed: {e}"))
+        })?;
 
     if response.status().is_success() {
-        return response
-            .json::<TokenResponse>()
-            .await
-            .map_err(|_| BadRequest("Failed to parse AniList token response".to_string()));
+        return response.json::<TokenResponse>().await.map_err(|e| {
+            sentry::capture_error(&e);
+            BadRequest(format!("Failed to parse AniList token response: {e}"))
+        });
     }
 
     let status = response.status();

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -115,7 +115,9 @@ pub async fn exchange_code_for_token(
         _ => "AniList token exchange failed",
     };
 
-    if status.is_server_error() {
+    if status.is_server_error()
+        || matches!(error_payload.as_str(), "invalid_client" | "invalid_request")
+    {
         let sentry_message = format!(
             "AniList token exchange returned upstream status {} with payload: {}",
             status.as_u16(),

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -38,12 +38,14 @@ pub async fn fetch_viewer_id(
         .await
         .map_err(|e| {
             sentry::capture_error(&e);
-            BadRequest(format!("Failed to fetch AniList viewer: {e}"))
+            error!("Failed to fetch AniList viewer: {e}");
+            BadRequest("Failed to fetch AniList viewer. Please try again.".to_string())
         })?
         .error_for_status()
         .map_err(|e| {
             sentry::capture_error(&e);
-            BadRequest(format!("AniList viewer request failed: {e}"))
+            error!("AniList viewer request failed: {e}");
+            BadRequest("AniList viewer request failed. Please try again.".to_string())
         })?;
 
     let viewer_response = viewer_response
@@ -51,7 +53,8 @@ pub async fn fetch_viewer_id(
         .await
         .map_err(|e| {
             sentry::capture_error(&e);
-            BadRequest(format!("Failed to parse AniList viewer: {e}"))
+            error!("Failed to parse AniList viewer: {e}");
+            BadRequest("Failed to parse AniList viewer response. Please try again.".to_string())
         })?;
 
     Ok(viewer_response.data.viewer.id)
@@ -78,13 +81,15 @@ pub async fn exchange_code_for_token(
         .await
         .map_err(|e| {
             sentry::capture_error(&e);
-            BadRequest(format!("AniList token exchange request failed: {e}"))
+            error!("AniList token exchange request failed: {e}");
+            BadRequest("AniList token exchange request failed. Please try again.".to_string())
         })?;
 
     if response.status().is_success() {
         return response.json::<TokenResponse>().await.map_err(|e| {
             sentry::capture_error(&e);
-            BadRequest(format!("Failed to parse AniList token response: {e}"))
+            error!("Failed to parse AniList token response: {e}");
+            BadRequest("Failed to parse AniList token response. Please try again.".to_string())
         });
     }
 

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -1,6 +1,6 @@
 use crate::utils::{
-    consts::ANILIST_USER_BASE,
-    structs::{OAuthCredential, OAuthSession, ViewerResponse},
+    consts::{ANILIST_TOKEN, ANILIST_USER_BASE},
+    structs::{OAuthCredential, OAuthSession, TokenErrorResponse, TokenResponse, ViewerResponse},
 };
 
 use chrono::{DateTime, Utc};
@@ -51,21 +51,64 @@ pub async fn fetch_viewer_id(
     Ok(viewer_response.data.viewer.id)
 }
 
-/// Prototype-era token save; keyed on anilist_id only. Used by the existing /authorized
-/// callback and will be replaced in ANNIE-129 when the full callback is rewritten.
-#[tracing::instrument(skip(access_token, db))]
-pub async fn save_access_token(
-    access_token: &str,
-    anilist_id: i64,
-    db: &Pool<Postgres>,
-) -> Result<(), sqlx::Error> {
-    info!("Saving access token ...");
-    sqlx::query("UPDATE users SET access_token=$1 WHERE anilist_id=$2")
-        .bind(access_token)
-        .bind(anilist_id)
-        .execute(db)
+pub async fn exchange_code_for_token(
+    client: &reqwest::Client,
+    client_id: &str,
+    client_secret: &str,
+    redirect_uri: &str,
+    code: &str,
+) -> Result<TokenResponse, BadRequest<String>> {
+    let response = client
+        .post(ANILIST_TOKEN)
+        .json(&json!({
+            "grant_type": "authorization_code",
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+            "code": code,
+        }))
+        .send()
         .await
-        .map(|_| ())
+        .map_err(|_| BadRequest("AniList token exchange request failed".to_string()))?;
+
+    if response.status().is_success() {
+        return response
+            .json::<TokenResponse>()
+            .await
+            .map_err(|_| BadRequest("Failed to parse AniList token response".to_string()));
+    }
+
+    let status = response.status();
+    let error_payload = response
+        .json::<TokenErrorResponse>()
+        .await
+        .ok()
+        .and_then(|payload| {
+            payload
+                .error
+                .or(payload.error_description)
+                .or(payload.message)
+        })
+        .unwrap_or_else(|| "unknown_error".to_string());
+
+    let friendly_message = match error_payload.as_str() {
+        "access_denied" => "Authorization was denied by AniList",
+        "invalid_grant" => "Authorization code is invalid or expired",
+        "invalid_client" => "AniList OAuth client configuration is invalid",
+        "invalid_request" => "AniList token exchange request was invalid",
+        _ => "AniList token exchange failed",
+    };
+
+    Err(BadRequest(format!(
+        "{friendly_message} (status: {})",
+        status.as_u16()
+    )))
+}
+
+pub fn token_expires_at(expires_in_seconds: Option<i64>) -> Option<DateTime<Utc>> {
+    expires_in_seconds
+        .filter(|seconds| *seconds > 0)
+        .map(|seconds| Utc::now() + chrono::Duration::seconds(seconds))
 }
 
 /// Upserts AniList OAuth credentials for the given Discord user. On conflict on
@@ -243,8 +286,8 @@ pub async fn consume_oauth_session(
 mod tests {
     use super::{
         SessionConsumeError, consume_oauth_session, fetch_credential_by_anilist_id,
-        fetch_credential_by_discord_user, insert_oauth_session, upsert_oauth_credentials,
-        verify_bot_signature,
+        fetch_credential_by_discord_user, insert_oauth_session, token_expires_at,
+        upsert_oauth_credentials, verify_bot_signature,
     };
     use chrono::{Duration, Utc};
     use hmac::{Hmac, Mac};
@@ -433,5 +476,13 @@ mod tests {
             .expect_err("expired session should fail");
 
         assert!(matches!(err, SessionConsumeError::Expired));
+    }
+
+    #[test]
+    fn token_expiry_is_only_created_for_positive_values() {
+        assert!(token_expires_at(None).is_none());
+        assert!(token_expires_at(Some(0)).is_none());
+        assert!(token_expires_at(Some(-10)).is_none());
+        assert!(token_expires_at(Some(1)).is_some());
     }
 }

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -106,13 +106,21 @@ pub async fn exchange_code_for_token(
         "invalid_grant" => "Authorization code is invalid or expired",
         "invalid_client" => "AniList OAuth client configuration is invalid",
         "invalid_request" => "AniList token exchange request was invalid",
+        _ if status.is_server_error() => "AniList is temporarily unavailable. Please try again.",
         _ => "AniList token exchange failed",
     };
 
-    Err(BadRequest(format!(
-        "{friendly_message} (status: {})",
-        status.as_u16()
-    )))
+    if status.is_server_error() {
+        let sentry_message = format!(
+            "AniList token exchange returned upstream status {} with payload: {}",
+            status.as_u16(),
+            error_payload
+        );
+        sentry::capture_message(&sentry_message, sentry::Level::Error);
+        error!("{sentry_message}");
+    }
+
+    Err(BadRequest(friendly_message.to_string()))
 }
 
 pub fn token_expires_at(expires_in_seconds: Option<i64>) -> Option<DateTime<Utc>> {

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -6,7 +6,6 @@ use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use nanoid::nanoid;
 use rocket::http::Status;
-use rocket::response::status::BadRequest;
 use serde_json::json;
 use sha2::Sha256;
 use sqlx::{Pool, Postgres};
@@ -38,12 +37,31 @@ impl TokenExchangeError {
     }
 }
 
+#[derive(Debug)]
+pub enum ViewerFetchError {
+    BadGateway(String),
+}
+
+impl ViewerFetchError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadGateway(message) => message.as_str(),
+        }
+    }
+
+    pub fn status(&self) -> Status {
+        match self {
+            Self::BadGateway(_) => Status::BadGateway,
+        }
+    }
+}
+
 #[tracing::instrument(skip(client, access_token))]
 pub async fn fetch_viewer_id(
     client: &reqwest::Client,
     user_endpoint: &str,
     access_token: &str,
-) -> Result<i64, BadRequest<String>> {
+) -> Result<i64, ViewerFetchError> {
     const USER_QUERY: &str = "
     query {
         Viewer {
@@ -61,13 +79,17 @@ pub async fn fetch_viewer_id(
         .map_err(|e| {
             sentry::capture_error(&e);
             error!("Failed to fetch AniList viewer: {e}");
-            BadRequest("Failed to fetch AniList viewer. Please try again.".to_string())
+            ViewerFetchError::BadGateway(
+                "Failed to fetch AniList viewer. Please try again.".to_string(),
+            )
         })?
         .error_for_status()
         .map_err(|e| {
             sentry::capture_error(&e);
             error!("AniList viewer request failed: {e}");
-            BadRequest("AniList viewer request failed. Please try again.".to_string())
+            ViewerFetchError::BadGateway(
+                "AniList viewer request failed. Please try again.".to_string(),
+            )
         })?;
 
     let viewer_response = viewer_response
@@ -76,12 +98,15 @@ pub async fn fetch_viewer_id(
         .map_err(|e| {
             sentry::capture_error(&e);
             error!("Failed to parse AniList viewer: {e}");
-            BadRequest("Failed to parse AniList viewer response. Please try again.".to_string())
+            ViewerFetchError::BadGateway(
+                "Failed to parse AniList viewer response. Please try again.".to_string(),
+            )
         })?;
 
     Ok(viewer_response.data.viewer.id)
 }
 
+#[tracing::instrument(skip(client, client_secret, code))]
 pub async fn exchange_code_for_token(
     client: &reqwest::Client,
     token_endpoint: &str,

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -5,6 +5,7 @@ use crate::utils::structs::{
 use chrono::{DateTime, Utc};
 use hmac::{Hmac, Mac};
 use nanoid::nanoid;
+use rocket::http::Status;
 use rocket::response::status::BadRequest;
 use serde_json::json;
 use sha2::Sha256;
@@ -14,6 +15,27 @@ use sqlx::{Pool, Postgres};
 pub enum UpsertOAuthCredentialsError {
     AlreadyLinked,
     Db(sqlx::Error),
+}
+
+#[derive(Debug)]
+pub enum TokenExchangeError {
+    BadRequest(String),
+    BadGateway(String),
+}
+
+impl TokenExchangeError {
+    pub fn message(&self) -> &str {
+        match self {
+            Self::BadRequest(message) | Self::BadGateway(message) => message.as_str(),
+        }
+    }
+
+    pub fn status(&self) -> Status {
+        match self {
+            Self::BadRequest(_) => Status::BadRequest,
+            Self::BadGateway(_) => Status::BadGateway,
+        }
+    }
 }
 
 #[tracing::instrument(skip(client, access_token))]
@@ -67,7 +89,7 @@ pub async fn exchange_code_for_token(
     client_secret: &str,
     redirect_uri: &str,
     code: &str,
-) -> Result<TokenResponse, BadRequest<String>> {
+) -> Result<TokenResponse, TokenExchangeError> {
     let response = client
         .post(token_endpoint)
         .json(&json!({
@@ -82,14 +104,18 @@ pub async fn exchange_code_for_token(
         .map_err(|e| {
             sentry::capture_error(&e);
             error!("AniList token exchange request failed: {e}");
-            BadRequest("AniList token exchange request failed. Please try again.".to_string())
+            TokenExchangeError::BadGateway(
+                "AniList token exchange request failed. Please try again.".to_string(),
+            )
         })?;
 
     if response.status().is_success() {
         return response.json::<TokenResponse>().await.map_err(|e| {
             sentry::capture_error(&e);
             error!("Failed to parse AniList token response: {e}");
-            BadRequest("Failed to parse AniList token response. Please try again.".to_string())
+            TokenExchangeError::BadGateway(
+                "Failed to parse AniList token response. Please try again.".to_string(),
+            )
         });
     }
 
@@ -127,7 +153,11 @@ pub async fn exchange_code_for_token(
         error!("{sentry_message}");
     }
 
-    Err(BadRequest(friendly_message.to_string()))
+    if status.is_server_error() {
+        Err(TokenExchangeError::BadGateway(friendly_message.to_string()))
+    } else {
+        Err(TokenExchangeError::BadRequest(friendly_message.to_string()))
+    }
 }
 
 pub fn token_expires_at(expires_in_seconds: Option<i64>) -> Option<DateTime<Utc>> {

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -1,6 +1,5 @@
-use crate::utils::{
-    consts::ANILIST_TOKEN,
-    structs::{OAuthCredential, OAuthSession, TokenErrorResponse, TokenResponse, ViewerResponse},
+use crate::utils::structs::{
+    OAuthCredential, OAuthSession, TokenErrorResponse, TokenResponse, ViewerResponse,
 };
 
 use chrono::{DateTime, Utc};
@@ -495,6 +494,8 @@ mod tests {
 
         assert_eq!(session.discord_user_id, "123456789");
         assert!(session.used_at.is_some());
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -504,6 +505,8 @@ mod tests {
             .expect_err("consume should fail");
 
         assert!(matches!(err, SessionConsumeError::NotFound));
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -521,6 +524,8 @@ mod tests {
             .expect_err("replay should fail");
 
         assert!(matches!(err, SessionConsumeError::AlreadyUsed));
+
+        pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -541,6 +546,8 @@ mod tests {
             .expect_err("expired session should fail");
 
         assert!(matches!(err, SessionConsumeError::Expired));
+
+        pool.close().await;
     }
 
     #[test]

--- a/src/utils/guards.rs
+++ b/src/utils/guards.rs
@@ -24,7 +24,7 @@ impl<'r> FromRequest<'r> for StateToken {
             Some(s) => &s.pool,
             None => {
                 error!("MyState not managed -- cannot validate OAuth session");
-                return Outcome::Error((Status::InternalServerError, StateTokenError::Invalid));
+                return Outcome::Error((Status::InternalServerError, StateTokenError::Internal));
             }
         };
 
@@ -49,7 +49,7 @@ impl<'r> FromRequest<'r> for StateToken {
             Err(SessionConsumeError::Db(e)) => {
                 sentry::capture_error(&e);
                 error!("Database error during state validation: {e}");
-                Outcome::Error((Status::InternalServerError, StateTokenError::Invalid))
+                Outcome::Error((Status::InternalServerError, StateTokenError::Internal))
             }
         }
     }

--- a/src/utils/structs.rs
+++ b/src/utils/structs.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
 
 pub struct MyState {
@@ -17,6 +17,20 @@ pub struct TokenResponse {
     pub refresh_token: Option<String>,
     pub expires_in: Option<i64>,
     pub token_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TokenErrorResponse {
+    pub error: Option<String>,
+    pub message: Option<String>,
+    pub error_description: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct CallbackResponse {
+    pub status: String,
+    pub code: String,
+    pub message: String,
 }
 
 #[derive(Debug, sqlx::FromRow)]

--- a/src/utils/structs.rs
+++ b/src/utils/structs.rs
@@ -80,6 +80,7 @@ pub enum StateTokenError {
     Invalid,
     Expired,
     Replayed,
+    Internal,
 }
 
 #[cfg(test)]

--- a/src/utils/structs.rs
+++ b/src/utils/structs.rs
@@ -7,6 +7,8 @@ pub struct MyState {
     pub client_secret: String,
     pub redirect_uri: String,
     pub bot_auth_secret: String,
+    pub token_endpoint: String,
+    pub user_endpoint: String,
     pub client: reqwest::Client,
     pub pool: PgPool,
 }


### PR DESCRIPTION
## Summary
Complete AniList OAuth callback handling with structured JSON callback responses, server-side state-to-Discord session validation, AniList credential persistence, deterministic already-linked handling, and safer upstream error reporting/logging.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes

- 3f454925540bb53d85b63cb4281ff152691ec1ff: Harden `/login` and `/authorized` to exchange AniList codes, fetch viewer identity, bind validated state to a Discord user, and persist AniList OAuth credentials.
- 49fabe3098d6e3b8486e507dfcdbc540f2e32b3a: Add mocked callback coverage for happy-path exchange/persistence plus AniList error cases using `wiremock`.
- d4474aa4bb60273ab4897836a0c59b40a5177274: Return a deterministic `already_linked` callback error when an AniList account is already connected to another Discord user.
- e5521f0638f61b11bf5547ec1a91b6b406f08865: Release Rocket/sqlx test clients and pools in login/session coverage to reduce DB-backed test leakage.
- 93d6bf8361411ddb920fb51e259e58766e1e39c2: Capture AniList credential persistence failures in Sentry from the callback handler.
- d3daabb8bb28caf8e20797d2ec8418ebcd205cdc: Normalize `/authorized` error responses so state validation failures return the same structured JSON shape as other callback errors.
- 6f148e2c13a4e51e9e3a6ff58c7e97e587b26c49: Replace raw upstream/network parse details in callback responses with user-safe AniList token/viewer failure messages and add regression coverage.
- 297d089be3bcf25ded9b46a306ec564f4020b4a0: Report AniList `invalid_client` and `invalid_request` token responses to Sentry as operational misconfiguration signals.
- c823cf01ae17d8252cfe163329a877978b4c605d: Sanitize upstream callback failures further by mapping token exchange transport/parse failures to `502` while keeping provider callback errors user-safe.

### Notes

- Duplicate-link handling aligns the callback contract with the ANNIE-129 implementation expectations for already-linked AniList accounts.
- State-token guard failures now return structured callback JSON instead of falling back to Rocket’s default error response format.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `doppler run -- cargo test --manifest-path "/Users/sekkensenzai/code/annie-mei/worktrees/annie-129-76r/Cargo.toml"`

---

This PR description was written by GPT-5.4.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/7" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
