### PR TITLE
[ANNIE-142]/Use local Postgres service container for CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,21 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
 
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: annie_mei_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -76,5 +91,5 @@ jobs:
 
       - name: Test
         env:
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          DATABASE_URL: postgres://postgres:postgres@localhost:5432/annie_mei_test
         run: cargo test


### PR DESCRIPTION
## Summary

- Replace remote Neon `DATABASE_URL` with a local Postgres 17 service container in CI
- Eliminates flaky `#[sqlx::test]` failures caused by network latency, Neon cold starts, and concurrent temporary DB creation against a remote instance

## Type of Change

- [x] Bug fix

## Changes

- d1d6c3e: Add Postgres 17 service container with health check to test job; replace `secrets.DATABASE_URL` with localhost connection string

### Notes

`#[sqlx::test]` creates and drops temporary databases for each test. Running 19 of these concurrently against a remote Neon instance introduced unpredictable latency and connection failures. A local service container eliminates all network-related flakiness while also being faster and fully self-contained.

## Validation

- [ ] CI passes with the new Postgres service container
- [ ] `cargo fmt --check` clean
- [ ] `cargo clippy` clean

---

This PR description was written by Claude Opus 4.6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/11" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
