### PR TITLE
[ANNIE-131]/handle AniList token expiry relink state

### DIFF
--- a/migrations/20260401000003_add_oauth_credential_relink_fields.down.sql
+++ b/migrations/20260401000003_add_oauth_credential_relink_fields.down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_credentials
+DROP COLUMN IF EXISTS relink_reason,
+DROP COLUMN IF EXISTS relink_required_at;

--- a/migrations/20260401000003_add_oauth_credential_relink_fields.up.sql
+++ b/migrations/20260401000003_add_oauth_credential_relink_fields.up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE oauth_credentials
+ADD COLUMN IF NOT EXISTS relink_required_at TIMESTAMPTZ,
+ADD COLUMN IF NOT EXISTS relink_reason TEXT;

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -275,6 +275,26 @@ pub fn credential_requires_relink(credential: &OAuthCredential) -> bool {
     credential.relink_required_at.is_some() || credential_is_expired(credential)
 }
 
+#[tracing::instrument(skip(db))]
+async fn mark_expired_oauth_credential_relink_required(
+    discord_user_id: &str,
+    reason: &str,
+    db: &Pool<Postgres>,
+) -> Result<bool, sqlx::Error> {
+    sqlx::query(
+        "UPDATE oauth_credentials \
+         SET relink_required_at = NOW(), relink_reason = $2 \
+         WHERE discord_user_id = $1 \
+           AND token_expires_at IS NOT NULL \
+           AND token_expires_at <= NOW()",
+    )
+    .bind(discord_user_id)
+    .bind(reason)
+    .execute(db)
+    .await
+    .map(|result| result.rows_affected() > 0)
+}
+
 #[derive(Debug)]
 pub enum UsableCredentialError {
     Missing,
@@ -351,24 +371,43 @@ pub async fn fetch_usable_oauth_credential(
         return Err(UsableCredentialError::Missing);
     };
 
-    if credential.relink_required_at.is_some() {
+    if !credential_requires_relink(&credential) {
+        return Ok(credential);
+    }
+
+    if !credential_is_expired(&credential) {
         return Err(UsableCredentialError::RelinkRequired);
     }
 
-    if credential_is_expired(&credential) {
-        mark_oauth_credentials_relink_required(discord_user_id, RELINK_REASON_TOKEN_EXPIRED, db)
+    if !mark_expired_oauth_credential_relink_required(
+        discord_user_id,
+        RELINK_REASON_TOKEN_EXPIRED,
+        db,
+    )
+    .await
+    .map_err(UsableCredentialError::Db)?
+    {
+        // Another request may have completed a relink between the stale read above
+        // and the conditional mark, so re-check the current row before forcing a relink.
+        let refreshed_credential = fetch_credential_by_discord_user(discord_user_id, db)
             .await
             .map_err(UsableCredentialError::Db)?;
 
-        let sentry_message =
-            "AniList credential expired and now requires relink. User must restart /register.";
-        sentry::capture_message(sentry_message, sentry::Level::Warning);
-        warn!("{sentry_message}");
-
-        return Err(UsableCredentialError::RelinkRequired);
+        return match refreshed_credential {
+            Some(credential) if credential_requires_relink(&credential) => {
+                Err(UsableCredentialError::RelinkRequired)
+            }
+            Some(credential) => Ok(credential),
+            None => Err(UsableCredentialError::Missing),
+        };
     }
 
-    Ok(credential)
+    let sentry_message =
+        "AniList credential expired and now requires relink. User must restart /register.";
+    sentry::capture_message(sentry_message, sentry::Level::Warning);
+    warn!("{sentry_message}");
+
+    Err(UsableCredentialError::RelinkRequired)
 }
 
 pub fn get_state_token() -> String {
@@ -507,8 +546,8 @@ mod tests {
         OAuthContextError, SessionConsumeError, UpsertOAuthCredentialsError, UsableCredentialError,
         consume_oauth_session, fetch_credential_by_anilist_id, fetch_credential_by_discord_user,
         fetch_usable_oauth_credential, insert_oauth_session,
-        mark_oauth_credentials_relink_required, token_expires_at, upsert_oauth_credentials,
-        verify_oauth_context,
+        mark_expired_oauth_credential_relink_required, mark_oauth_credentials_relink_required,
+        token_expires_at, upsert_oauth_credentials, verify_oauth_context,
     };
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use chrono::{Duration, Utc};
@@ -725,6 +764,39 @@ mod tests {
 
         assert!(credential.relink_required_at.is_some());
         assert_eq!(credential.relink_reason.as_deref(), Some("token_expired"));
+
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn mark_expired_oauth_credential_relink_required_skips_fresh_credentials(
+        pool: Pool<Postgres>,
+    ) {
+        upsert_oauth_credentials(
+            "race_user",
+            999,
+            "fresh_access",
+            None,
+            Some(Utc::now() + Duration::hours(2)),
+            &pool,
+        )
+        .await
+        .expect("upsert should succeed");
+
+        let marked =
+            mark_expired_oauth_credential_relink_required("race_user", "token_expired", &pool)
+                .await
+                .expect("conditional mark should succeed");
+
+        assert!(!marked);
+
+        let credential = fetch_credential_by_discord_user("race_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert!(credential.relink_required_at.is_none());
+        assert!(credential.relink_reason.is_none());
 
         pool.close().await;
     }

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -285,6 +285,7 @@ async fn mark_expired_oauth_credential_relink_required(
         "UPDATE oauth_credentials \
          SET relink_required_at = NOW(), relink_reason = $2 \
          WHERE discord_user_id = $1 \
+           AND relink_required_at IS NULL \
            AND token_expires_at IS NOT NULL \
            AND token_expires_at <= NOW()",
     )
@@ -376,10 +377,6 @@ pub async fn fetch_usable_oauth_credential(
     }
 
     if credential.relink_required_at.is_some() {
-        return Err(UsableCredentialError::RelinkRequired);
-    }
-
-    if !credential_is_expired(&credential) {
         return Err(UsableCredentialError::RelinkRequired);
     }
 
@@ -849,6 +846,58 @@ mod tests {
 
         assert!(credential.relink_required_at.is_none());
         assert!(credential.relink_reason.is_none());
+
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn mark_expired_oauth_credential_relink_required_skips_already_flagged_credentials(
+        pool: Pool<Postgres>,
+    ) {
+        upsert_oauth_credentials(
+            "already_marked_user",
+            1_000,
+            "expired_access",
+            None,
+            Some(Utc::now() - Duration::minutes(5)),
+            &pool,
+        )
+        .await
+        .expect("upsert should succeed");
+
+        mark_oauth_credentials_relink_required("already_marked_user", "token_expired", &pool)
+            .await
+            .expect("mark relink required should succeed");
+
+        let initially_flagged = fetch_credential_by_discord_user("already_marked_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        let initial_relink_required_at = initially_flagged
+            .relink_required_at
+            .expect("credential should already be flagged for relink");
+
+        let marked = mark_expired_oauth_credential_relink_required(
+            "already_marked_user",
+            "token_expired",
+            &pool,
+        )
+        .await
+        .expect("conditional mark should succeed");
+
+        assert!(!marked);
+
+        let credential = fetch_credential_by_discord_user("already_marked_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert_eq!(
+            credential.relink_required_at,
+            Some(initial_relink_required_at)
+        );
+        assert_eq!(credential.relink_reason.as_deref(), Some("token_expired"));
 
         pool.close().await;
     }

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -375,6 +375,10 @@ pub async fn fetch_usable_oauth_credential(
         return Ok(credential);
     }
 
+    if credential.relink_required_at.is_some() {
+        return Err(UsableCredentialError::RelinkRequired);
+    }
+
     if !credential_is_expired(&credential) {
         return Err(UsableCredentialError::RelinkRequired);
     }
@@ -763,6 +767,54 @@ mod tests {
             .expect("credential should exist");
 
         assert!(credential.relink_required_at.is_some());
+        assert_eq!(credential.relink_reason.as_deref(), Some("token_expired"));
+
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn fetch_usable_oauth_credential_does_not_remark_already_flagged_credentials(
+        pool: Pool<Postgres>,
+    ) {
+        upsert_oauth_credentials(
+            "already_flagged_user",
+            778,
+            "expired_access",
+            None,
+            Some(Utc::now() - Duration::minutes(5)),
+            &pool,
+        )
+        .await
+        .expect("upsert should succeed");
+
+        mark_oauth_credentials_relink_required("already_flagged_user", "token_expired", &pool)
+            .await
+            .expect("mark relink required should succeed");
+
+        let initially_flagged = fetch_credential_by_discord_user("already_flagged_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        let initial_relink_required_at = initially_flagged
+            .relink_required_at
+            .expect("credential should already be flagged for relink");
+
+        let error = fetch_usable_oauth_credential("already_flagged_user", &pool)
+            .await
+            .expect_err("flagged credentials should still require relink");
+
+        assert!(matches!(error, UsableCredentialError::RelinkRequired));
+
+        let credential = fetch_credential_by_discord_user("already_flagged_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert_eq!(
+            credential.relink_required_at,
+            Some(initial_relink_required_at)
+        );
         assert_eq!(credential.relink_reason.as_deref(), Some("token_expired"));
 
         pool.close().await;

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -4,7 +4,7 @@ use crate::utils::structs::{
 };
 
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration, Utc};
 use hmac::{Hmac, Mac};
 use nanoid::nanoid;
 use rocket::http::Status;
@@ -14,6 +14,10 @@ use sqlx::{Pool, Postgres};
 
 const CONTEXT_VERSION: u8 = 1;
 const MAX_CONTEXT_FUTURE_SKEW_SECONDS: i64 = 60;
+const DEFAULT_ANILIST_ACCESS_TOKEN_TTL_SECONDS: i64 = 31_536_000;
+const RELINK_REASON_TOKEN_EXPIRED: &str = "token_expired";
+
+pub const RELINK_REQUIRED_MESSAGE: &str = "Your AniList link has expired or needs to be reconnected. Please run `/register` again in Discord.";
 
 #[derive(Debug)]
 pub enum UpsertOAuthCredentialsError {
@@ -205,9 +209,13 @@ pub async fn exchange_code_for_token(
 }
 
 pub fn token_expires_at(expires_in_seconds: Option<i64>) -> Option<DateTime<Utc>> {
-    expires_in_seconds
-        .filter(|seconds| *seconds > 0)
-        .map(|seconds| Utc::now() + chrono::Duration::seconds(seconds))
+    let expires_in_seconds = match expires_in_seconds {
+        Some(seconds) if seconds > 0 => seconds,
+        Some(_) => return None,
+        None => DEFAULT_ANILIST_ACCESS_TOKEN_TTL_SECONDS,
+    };
+
+    Some(Utc::now() + Duration::seconds(expires_in_seconds))
 }
 
 #[tracing::instrument(skip(access_token, refresh_token, db))]
@@ -255,6 +263,23 @@ pub async fn upsert_oauth_credentials(
         }
     })
     .map(|_| ())
+}
+
+pub fn credential_is_expired(credential: &OAuthCredential) -> bool {
+    credential
+        .token_expires_at
+        .is_some_and(|expires_at| expires_at <= Utc::now())
+}
+
+pub fn credential_requires_relink(credential: &OAuthCredential) -> bool {
+    credential.relink_required_at.is_some() || credential_is_expired(credential)
+}
+
+#[derive(Debug)]
+pub enum UsableCredentialError {
+    Missing,
+    RelinkRequired,
+    Db(sqlx::Error),
 }
 
 #[tracing::instrument(skip(db))]
@@ -312,6 +337,38 @@ pub async fn fetch_credential_by_anilist_id(
     .bind(anilist_id)
     .fetch_optional(db)
     .await
+}
+
+#[tracing::instrument(skip(db))]
+pub async fn fetch_usable_oauth_credential(
+    discord_user_id: &str,
+    db: &Pool<Postgres>,
+) -> Result<OAuthCredential, UsableCredentialError> {
+    let Some(credential) = fetch_credential_by_discord_user(discord_user_id, db)
+        .await
+        .map_err(UsableCredentialError::Db)?
+    else {
+        return Err(UsableCredentialError::Missing);
+    };
+
+    if credential.relink_required_at.is_some() {
+        return Err(UsableCredentialError::RelinkRequired);
+    }
+
+    if credential_is_expired(&credential) {
+        mark_oauth_credentials_relink_required(discord_user_id, RELINK_REASON_TOKEN_EXPIRED, db)
+            .await
+            .map_err(UsableCredentialError::Db)?;
+
+        let sentry_message =
+            "AniList credential expired and now requires relink. User must restart /register.";
+        sentry::capture_message(sentry_message, sentry::Level::Warning);
+        warn!("{sentry_message}");
+
+        return Err(UsableCredentialError::RelinkRequired);
+    }
+
+    Ok(credential)
 }
 
 pub fn get_state_token() -> String {
@@ -447,8 +504,9 @@ pub async fn consume_oauth_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        OAuthContextError, SessionConsumeError, UpsertOAuthCredentialsError, consume_oauth_session,
-        fetch_credential_by_anilist_id, fetch_credential_by_discord_user, insert_oauth_session,
+        OAuthContextError, SessionConsumeError, UpsertOAuthCredentialsError, UsableCredentialError,
+        consume_oauth_session, fetch_credential_by_anilist_id, fetch_credential_by_discord_user,
+        fetch_usable_oauth_credential, insert_oauth_session,
         mark_oauth_credentials_relink_required, token_expires_at, upsert_oauth_credentials,
         verify_oauth_context,
     };
@@ -642,6 +700,59 @@ mod tests {
     }
 
     #[sqlx::test(migrations = "./migrations")]
+    async fn fetch_usable_oauth_credential_marks_expired_tokens_for_relink(pool: Pool<Postgres>) {
+        upsert_oauth_credentials(
+            "expired_user",
+            777,
+            "expired_access",
+            None,
+            Some(Utc::now() - Duration::minutes(5)),
+            &pool,
+        )
+        .await
+        .expect("upsert should succeed");
+
+        let error = fetch_usable_oauth_credential("expired_user", &pool)
+            .await
+            .expect_err("expired credentials should require relink");
+
+        assert!(matches!(error, UsableCredentialError::RelinkRequired));
+
+        let credential = fetch_credential_by_discord_user("expired_user", &pool)
+            .await
+            .expect("fetch should not error")
+            .expect("credential should exist");
+
+        assert!(credential.relink_required_at.is_some());
+        assert_eq!(credential.relink_reason.as_deref(), Some("token_expired"));
+
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn fetch_usable_oauth_credential_returns_active_credentials(pool: Pool<Postgres>) {
+        upsert_oauth_credentials(
+            "active_user",
+            888,
+            "active_access",
+            None,
+            Some(Utc::now() + Duration::hours(6)),
+            &pool,
+        )
+        .await
+        .expect("upsert should succeed");
+
+        let credential = fetch_usable_oauth_credential("active_user", &pool)
+            .await
+            .expect("active credentials should remain usable");
+
+        assert_eq!(credential.access_token, "active_access");
+        assert!(credential.relink_required_at.is_none());
+
+        pool.close().await;
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
     async fn fetch_by_discord_user_returns_none_when_absent(pool: Pool<Postgres>) {
         let result = fetch_credential_by_discord_user("nonexistent", &pool)
             .await
@@ -771,8 +882,12 @@ mod tests {
     }
 
     #[test]
-    fn token_expiry_is_only_created_for_positive_values() {
-        assert!(token_expires_at(None).is_none());
+    fn token_expiry_defaults_to_one_year_when_missing() {
+        let default_expiry =
+            token_expires_at(None).expect("AniList tokens should default to 1 year");
+
+        assert!(default_expiry > Utc::now() + Duration::days(364));
+        assert!(default_expiry < Utc::now() + Duration::days(366));
         assert!(token_expires_at(Some(0)).is_none());
         assert!(token_expires_at(Some(-10)).is_none());
         assert!(token_expires_at(Some(1)).is_some());

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -236,7 +236,9 @@ pub async fn upsert_oauth_credentials(
              access_token = EXCLUDED.access_token, \
              refresh_token = EXCLUDED.refresh_token, \
              token_expires_at = EXCLUDED.token_expires_at, \
-             token_updated_at = NOW()",
+             token_updated_at = NOW(), \
+             relink_required_at = NULL, \
+             relink_reason = NULL",
     )
     .bind(discord_user_id)
     .bind(anilist_id)
@@ -252,6 +254,24 @@ pub async fn upsert_oauth_credentials(
             UpsertOAuthCredentialsError::Db(error)
         }
     })
+    .map(|_| ())
+}
+
+#[tracing::instrument(skip(db))]
+pub async fn mark_oauth_credentials_relink_required(
+    discord_user_id: &str,
+    reason: &str,
+    db: &Pool<Postgres>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE oauth_credentials \
+         SET relink_required_at = NOW(), relink_reason = $2 \
+         WHERE discord_user_id = $1",
+    )
+    .bind(discord_user_id)
+    .bind(reason)
+    .execute(db)
+    .await
     .map(|_| ())
 }
 
@@ -271,7 +291,7 @@ pub async fn fetch_credential_by_discord_user(
 ) -> Result<Option<OAuthCredential>, sqlx::Error> {
     sqlx::query_as::<_, OAuthCredential>(
         "SELECT discord_user_id, anilist_id, access_token, refresh_token, \
-         token_expires_at, token_updated_at, created_at \
+         token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
          FROM oauth_credentials WHERE discord_user_id = $1",
     )
     .bind(discord_user_id)
@@ -286,7 +306,7 @@ pub async fn fetch_credential_by_anilist_id(
 ) -> Result<Option<OAuthCredential>, sqlx::Error> {
     sqlx::query_as::<_, OAuthCredential>(
         "SELECT discord_user_id, anilist_id, access_token, refresh_token, \
-         token_expires_at, token_updated_at, created_at \
+         token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
          FROM oauth_credentials WHERE anilist_id = $1",
     )
     .bind(anilist_id)
@@ -429,7 +449,8 @@ mod tests {
     use super::{
         OAuthContextError, SessionConsumeError, UpsertOAuthCredentialsError, consume_oauth_session,
         fetch_credential_by_anilist_id, fetch_credential_by_discord_user, insert_oauth_session,
-        token_expires_at, upsert_oauth_credentials, verify_oauth_context,
+        mark_oauth_credentials_relink_required, token_expires_at, upsert_oauth_credentials,
+        verify_oauth_context,
     };
     use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use chrono::{Duration, Utc};
@@ -599,6 +620,10 @@ mod tests {
             .await
             .expect("first upsert should succeed");
 
+        mark_oauth_credentials_relink_required("user1", "token_expired", &pool)
+            .await
+            .expect("mark relink required should succeed");
+
         upsert_oauth_credentials("user1", 111, "new_token", Some("new_refresh"), None, &pool)
             .await
             .expect("second upsert should succeed");
@@ -610,6 +635,8 @@ mod tests {
 
         assert_eq!(cred.access_token, "new_token");
         assert_eq!(cred.refresh_token.as_deref(), Some("new_refresh"));
+        assert!(cred.relink_required_at.is_none());
+        assert!(cred.relink_reason.is_none());
 
         pool.close().await;
     }

--- a/src/utils/structs.rs
+++ b/src/utils/structs.rs
@@ -49,6 +49,8 @@ pub struct OAuthCredential {
     pub refresh_token: Option<String>,
     pub token_expires_at: Option<DateTime<Utc>>,
     pub token_updated_at: DateTime<Utc>,
+    pub relink_required_at: Option<DateTime<Utc>>,
+    pub relink_reason: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 


### PR DESCRIPTION
## Summary

Handle AniList credential expiry as a relink flow instead of a refresh-token flow.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Chore

## Changes

- 3104dfd98d630d72dd8842991f8a14883262af81: add relink-required fields to persisted OAuth credentials and clear them on successful relink
- 501c1cabd863f684b4dabdce1036b67ae430b134: default missing AniList token expiry to one year, mark expired credentials as relink-required, and add regression coverage for active vs expired credentials

### Notes

AniList's current official OAuth docs say access tokens are long-lived for 1 year and refresh tokens are not currently supported. This PR therefore implements expiry awareness plus relink handling rather than a refresh-token exchange flow.

Parallel reruns of the `sqlx` test suite can intermittently hit transient Postgres teardown errors (`55006`, database being accessed by other users). The full suite passed cleanly during validation with Doppler-backed secrets.

## Validation

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `doppler run -- cargo test`

## References (optional)

- ANNIE-131

---

This PR description was written by Amp.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/12" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
