### PR TITLE
[ANNIE-134]/Add railway.toml for Railway deployment

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -2,7 +2,7 @@
 builder = "RAILPACK"
 
 [deploy]
-startCommand = "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./annie-mei-auth"
+startCommand = "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./bin/annie-mei-auth"
 healthcheckPath = "/healthz"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,8 @@
+[build]
+builder = "RAILPACK"
+
+[deploy]
+healthcheckPath = "/healthz"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 5

--- a/railway.toml
+++ b/railway.toml
@@ -2,6 +2,7 @@
 builder = "RAILPACK"
 
 [deploy]
+startCommand = "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./annie-mei-auth"
 healthcheckPath = "/healthz"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"

--- a/railway.toml
+++ b/railway.toml
@@ -4,6 +4,6 @@ builder = "RAILPACK"
 [deploy]
 startCommand = "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./bin/annie-mei-auth"
 healthcheckPath = "/healthz"
-healthcheckTimeout = 300
+healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5


### PR DESCRIPTION
## Summary

- Adds `railway.toml` to configure Railpack builds, health checks, restart policy, and Rocket port bridging for Railway hosting.

## Type of Change

- [x] Infrastructure

## Changes

- 79171e7: Add railway.toml with Railpack builder, /healthz health check, and ON_FAILURE restart policy
- e1b90d9: Add start command to bridge Railway's dynamic PORT to ROCKET_PORT

### Notes

- Railway auto-assigns `PORT` at runtime; Rocket expects `ROCKET_PORT`. The start command bridges this: `ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./annie-mei-auth`
- Railpack was chosen over a Dockerfile for better Rust build caching (cargo registry, git, and target dir caching) and zero-config toolchain detection from `rust-toolchain.toml`
- Railway project `annie-mei-auth` has been provisioned in the `annie-mei` workspace with a production environment
- Secrets are synced one-way from Doppler
- Public domain: `https://auth-production-d749.up.railway.app`
- Replica limits set to 1 vCPU / 1 GB in the Railway dashboard (not configurable via config-as-code)

## Validation

- [x] Railway project provisioned and service created via CLI
- [x] Doppler sync configured for environment variables
- [x] Public domain assigned with TLS
- [ ] `/healthz` endpoint reachable over HTTPS (pending deploy completion)
- [ ] AniList OAuth callback verified against Railway-hosted service

## References

- [ANNIE-134](https://linear.app/annie-mei/issue/ANNIE-134/provision-and-host-auth-service-on-railway-for-anilist-oauth)

---

This PR description was written by Claude Opus 4.6.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
