### PR TITLE
[ANNIE-159]/store AniList username in OAuth credentials

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei-auth"
-version = "1.0.6"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei-auth"
-version = "1.0.6"
+version = "1.1.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/docs/oauth-contract.md
+++ b/docs/oauth-contract.md
@@ -47,12 +47,15 @@ shared Postgres database — it has no Diesel-managed tables of its own.
 Source of truth for **linked** AniList accounts. Migrations live in
 [`migrations/20260328000001_create_oauth_credentials.up.sql`](../migrations/20260328000001_create_oauth_credentials.up.sql)
 and
-[`migrations/20260401000003_add_oauth_credential_relink_fields.up.sql`](../migrations/20260401000003_add_oauth_credential_relink_fields.up.sql).
+[`migrations/20260401000003_add_oauth_credential_relink_fields.up.sql`](../migrations/20260401000003_add_oauth_credential_relink_fields.up.sql),
+plus
+[`migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql`](../migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql).
 
 | Column                | Type            | Notes                                                                           |
 | --------------------- | --------------- | ------------------------------------------------------------------------------- |
 | `discord_user_id`     | `TEXT` (PK)     | Raw Discord snowflake **as a string** (matches the bot's `user.id.get().to_string()`). |
 | `anilist_id`          | `BIGINT`        | AniList user ID. Unique across the table.                                       |
+| `anilist_username`    | `TEXT NULL`     | Public AniList username captured from the OAuth viewer response for friendly linked-account displays. |
 | `access_token`        | `TEXT`          | AniList OAuth access token.                                                     |
 | `refresh_token`       | `TEXT NULL`     | AniList OAuth refresh token, when issued.                                       |
 | `token_expires_at`    | `TIMESTAMPTZ NULL` | Token expiry, when AniList provides one.                                        |
@@ -65,6 +68,12 @@ and
 [`src/utils/functions.rs`](../src/utils/functions.rs), called from
 [`src/routes/authorized.rs`](../src/routes/authorized.rs) on a
 successful AniList token exchange.
+
+`anilist_username` is nullable so existing linked users can keep working
+after the migration. It is populated on the next successful OAuth
+callback/relink. Existing rows can be backfilled by querying AniList for
+each stored `anilist_id` and updating `anilist_username`, or users can
+run `/register` again after `/unregister` to relink.
 
 **Bot reads:** `OAuthCredential::get_by_discord_id` (used by
 `/whoami`) and `OAuthCredential::get_by_discord_ids` (used by the
@@ -142,13 +151,17 @@ When making one of those changes:
 
 `oauth_credentials.discord_user_id` and `oauth_sessions.discord_user_id`
 intentionally store the raw Discord snowflake so that `/register`,
-`/whoami`, and `/unregister` can all match on the same value. **Logs,
-spans, and Sentry telemetry must not include the raw snowflake.** Use
+`/whoami`, and `/unregister` can all match on the same value. The
+`oauth_credentials.anilist_id` and `oauth_credentials.anilist_username`
+fields are also user-identifying account-linkage data. **Logs, spans,
+metrics labels, breadcrumbs, and Sentry telemetry must not include any
+of those raw identifiers.** Use
 `utils::observability::identifier_fingerprint` (this service) or
-`crate::utils::privacy::hash_user_id` (bot) to emit a salted hash
-instead. Both helpers use the shared `USERID_HASH_SALT` environment
-variable so fingerprints correlate across repos; keep that variable
-listed in the [README environment variables](../README.md#environment-variables).
+`crate::utils::privacy::hash_user_id` (bot) to emit a salted hash when a
+stable correlation key is needed. Both helpers use the shared
+`USERID_HASH_SALT` environment variable so fingerprints correlate across
+repos; keep that variable listed in the
+[README environment variables](../README.md#environment-variables).
 
 The `ctx` query parameter on `/oauth/anilist/start` is base64url-encoded
 JSON plus a signature, not encrypted data. It contains raw

--- a/migrations/20260505000001_add_anilist_username_to_oauth_credentials.down.sql
+++ b/migrations/20260505000001_add_anilist_username_to_oauth_credentials.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_credentials
+DROP COLUMN anilist_username;

--- a/migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql
+++ b/migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oauth_credentials
+ADD COLUMN anilist_username TEXT NULL;

--- a/src/routes/authorized.rs
+++ b/src/routes/authorized.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     functions::{
-        UpsertOAuthCredentialsError, exchange_code_for_token, fetch_viewer_id, token_expires_at,
-        upsert_oauth_credentials,
+        LinkedAniListAccount, UpsertOAuthCredentialsError, exchange_code_for_token,
+        fetch_viewer_identity, token_expires_at, upsert_oauth_credentials,
     },
     observability::{configure_oauth_scope, identifier_fingerprint, record_identifier_fingerprint},
     structs::{MyState, StateToken, StateTokenError},
@@ -79,7 +79,7 @@ pub async fn authorized(
     let token_expires_at = token_expires_at(token_response.expires_in);
 
     info!("Fetching User data ...");
-    let anilist_id = match fetch_viewer_id(
+    let viewer = match fetch_viewer_identity(
         &state.client,
         state.user_endpoint.as_str(),
         &token_response.access_token,
@@ -87,14 +87,14 @@ pub async fn authorized(
     )
     .await
     {
-        Ok(user_id) => {
+        Ok(viewer) => {
             record_identifier_fingerprint(
                 &span,
                 "anilist_fingerprint",
-                &user_id.to_string(),
+                &viewer.id.to_string(),
                 &state.user_id_hash_salt,
             );
-            user_id
+            viewer
         }
         Err(error) => return callback_error(error.message(), error.status()),
     };
@@ -102,7 +102,10 @@ pub async fn authorized(
 
     if let Err(error) = upsert_oauth_credentials(
         &state_token.0,
-        anilist_id,
+        LinkedAniListAccount {
+            id: viewer.id,
+            username: &viewer.name,
+        },
         &token_response.access_token,
         token_response.refresh_token.as_deref(),
         token_expires_at,
@@ -286,7 +289,9 @@ mod tests {
     use crate::{
         routes::start::start,
         utils::{
-            functions::{fetch_credential_by_discord_user, upsert_oauth_credentials},
+            functions::{
+                LinkedAniListAccount, fetch_credential_by_discord_user, upsert_oauth_credentials,
+            },
             structs::MyState,
         },
     };
@@ -388,7 +393,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "data": { "Viewer": { "id": 12345 } }
+                "data": { "Viewer": { "id": 12345, "name": "AniUser" } }
             })))
             .mount(&mock_server)
             .await;
@@ -425,6 +430,7 @@ mod tests {
 
         assert_eq!(persisted.discord_user_id, "555666777888");
         assert_eq!(persisted.anilist_id, 12345);
+        assert_eq!(persisted.anilist_username.as_deref(), Some("AniUser"));
         assert_eq!(persisted.access_token, "access_1");
         assert_eq!(persisted.refresh_token.as_deref(), Some("refresh_1"));
         assert!(persisted.token_expires_at.is_some());
@@ -776,7 +782,10 @@ mod tests {
     ) {
         upsert_oauth_credentials(
             "existing_user",
-            12345,
+            LinkedAniListAccount {
+                id: 12345,
+                username: "ExistingUser",
+            },
             "existing_access",
             None,
             None,
@@ -802,7 +811,7 @@ mod tests {
         Mock::given(method("POST"))
             .and(path("/graphql"))
             .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "data": { "Viewer": { "id": 12345 } }
+                "data": { "Viewer": { "id": 12345, "name": "AniUser" } }
             })))
             .mount(&mock_server)
             .await;

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -114,7 +114,7 @@ pub async fn fetch_viewer_identity(
                 |scope| {
                     configure_oauth_scope(
                         scope,
-                        "oauth.callback.fetch_viewer_id",
+                        "oauth.callback.fetch_viewer_identity",
                         discord_user_fingerprint,
                     )
                 },
@@ -131,7 +131,7 @@ pub async fn fetch_viewer_identity(
                 |scope| {
                     configure_oauth_scope(
                         scope,
-                        "oauth.callback.fetch_viewer_id",
+                        "oauth.callback.fetch_viewer_identity",
                         discord_user_fingerprint,
                     )
                 },
@@ -151,7 +151,7 @@ pub async fn fetch_viewer_identity(
                 |scope| {
                     configure_oauth_scope(
                         scope,
-                        "oauth.callback.fetch_viewer_id",
+                        "oauth.callback.fetch_viewer_identity",
                         discord_user_fingerprint,
                     )
                 },

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -2,7 +2,7 @@ use crate::utils::observability::{
     configure_oauth_scope, identifier_fingerprint, record_identifier_fingerprint,
 };
 use crate::utils::structs::{
-    OAuthContextPayload, OAuthCredential, OAuthSession, TokenErrorResponse, TokenResponse,
+    OAuthContextPayload, OAuthCredential, OAuthSession, TokenErrorResponse, TokenResponse, Viewer,
     ViewerResponse,
 };
 
@@ -26,6 +26,12 @@ pub const RELINK_REQUIRED_MESSAGE: &str = "Your AniList link has expired or need
 pub enum UpsertOAuthCredentialsError {
     AlreadyLinked,
     Db(sqlx::Error),
+}
+
+#[derive(Clone, Copy)]
+pub struct LinkedAniListAccount<'a> {
+    pub id: i64,
+    pub username: &'a str,
 }
 
 #[derive(Debug)]
@@ -82,16 +88,17 @@ pub enum OAuthContextError {
 }
 
 #[tracing::instrument(skip(client, access_token))]
-pub async fn fetch_viewer_id(
+pub async fn fetch_viewer_identity(
     client: &reqwest::Client,
     user_endpoint: &str,
     access_token: &str,
     discord_user_fingerprint: Option<&str>,
-) -> Result<i64, ViewerFetchError> {
+) -> Result<Viewer, ViewerFetchError> {
     const USER_QUERY: &str = "
     query {
         Viewer {
             id
+            name
         }
     }
     ";
@@ -156,7 +163,7 @@ pub async fn fetch_viewer_id(
             )
         })?;
 
-    Ok(viewer_response.data.viewer.id)
+    Ok(viewer_response.data.viewer)
 }
 
 #[tracing::instrument(skip(client, client_secret, code))]
@@ -290,12 +297,12 @@ pub fn token_expires_at(expires_in_seconds: Option<i64>) -> Option<DateTime<Utc>
 }
 
 #[tracing::instrument(
-    skip(access_token, refresh_token, discord_user_id, user_id_hash_salt, db),
+    skip(access_token, refresh_token, discord_user_id, anilist_account, user_id_hash_salt, db),
     fields(discord_user_fingerprint = tracing::field::Empty)
 )]
 pub async fn upsert_oauth_credentials(
     discord_user_id: &str,
-    anilist_id: i64,
+    anilist_account: LinkedAniListAccount<'_>,
     access_token: &str,
     refresh_token: Option<&str>,
     token_expires_at: Option<DateTime<Utc>>,
@@ -309,9 +316,10 @@ pub async fn upsert_oauth_credentials(
         user_id_hash_salt,
     );
 
-    if let Some(existing) = fetch_credential_by_anilist_id(anilist_id, user_id_hash_salt, db)
-        .await
-        .map_err(UpsertOAuthCredentialsError::Db)?
+    if let Some(existing) =
+        fetch_credential_by_anilist_id(anilist_account.id, user_id_hash_salt, db)
+            .await
+            .map_err(UpsertOAuthCredentialsError::Db)?
         && existing.discord_user_id != discord_user_id
     {
         return Err(UpsertOAuthCredentialsError::AlreadyLinked);
@@ -319,10 +327,11 @@ pub async fn upsert_oauth_credentials(
 
     sqlx::query(
         "INSERT INTO oauth_credentials \
-         (discord_user_id, anilist_id, access_token, refresh_token, token_expires_at, token_updated_at) \
-         VALUES ($1, $2, $3, $4, $5, NOW()) \
+         (discord_user_id, anilist_id, anilist_username, access_token, refresh_token, token_expires_at, token_updated_at) \
+         VALUES ($1, $2, $3, $4, $5, $6, NOW()) \
          ON CONFLICT (discord_user_id) DO UPDATE SET \
              anilist_id = EXCLUDED.anilist_id, \
+             anilist_username = EXCLUDED.anilist_username, \
              access_token = EXCLUDED.access_token, \
              refresh_token = EXCLUDED.refresh_token, \
              token_expires_at = EXCLUDED.token_expires_at, \
@@ -331,7 +340,8 @@ pub async fn upsert_oauth_credentials(
              relink_reason = NULL",
     )
     .bind(discord_user_id)
-    .bind(anilist_id)
+    .bind(anilist_account.id)
+    .bind(anilist_account.username)
     .bind(access_token)
     .bind(refresh_token)
     .bind(token_expires_at)
@@ -451,7 +461,7 @@ pub async fn fetch_credential_by_discord_user(
     );
 
     sqlx::query_as::<_, OAuthCredential>(
-        "SELECT discord_user_id, anilist_id, access_token, refresh_token, \
+        "SELECT discord_user_id, anilist_id, anilist_username, access_token, refresh_token, \
          token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
          FROM oauth_credentials WHERE discord_user_id = $1",
     )
@@ -478,7 +488,7 @@ pub async fn fetch_credential_by_anilist_id(
     );
 
     sqlx::query_as::<_, OAuthCredential>(
-        "SELECT discord_user_id, anilist_id, access_token, refresh_token, \
+        "SELECT discord_user_id, anilist_id, anilist_username, access_token, refresh_token, \
          token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
          FROM oauth_credentials WHERE anilist_id = $1",
     )
@@ -707,9 +717,9 @@ pub async fn consume_oauth_session(
 #[cfg(test)]
 mod tests {
     use super::{
-        OAuthContextError, SessionConsumeError, UpsertOAuthCredentialsError, UsableCredentialError,
-        consume_oauth_session, fetch_credential_by_anilist_id, fetch_credential_by_discord_user,
-        fetch_usable_oauth_credential, insert_oauth_session,
+        LinkedAniListAccount, OAuthContextError, SessionConsumeError, UpsertOAuthCredentialsError,
+        UsableCredentialError, consume_oauth_session, fetch_credential_by_anilist_id,
+        fetch_credential_by_discord_user, fetch_usable_oauth_credential, insert_oauth_session,
         mark_expired_oauth_credential_relink_required, mark_oauth_credentials_relink_required,
         token_expires_at, upsert_oauth_credentials, verify_oauth_context,
     };
@@ -721,6 +731,10 @@ mod tests {
     use sqlx::{Pool, Postgres};
 
     const TEST_USERID_HASH_SALT: &str = "test-userid-hash-salt";
+
+    fn linked_account(id: i64, username: &'static str) -> LinkedAniListAccount<'static> {
+        LinkedAniListAccount { id, username }
+    }
 
     fn make_ctx(payload: serde_json::Value, secret: &str) -> String {
         type HmacSha256 = Hmac<Sha256>;
@@ -854,7 +868,7 @@ mod tests {
     async fn upsert_inserts_new_credential(pool: Pool<Postgres>) {
         upsert_oauth_credentials(
             "111222333444555666",
-            987654321,
+            linked_account(987654321, "AniUser"),
             "access_tok",
             Some("refresh_tok"),
             Some(Utc::now() + Duration::hours(1)),
@@ -872,6 +886,7 @@ mod tests {
 
         assert_eq!(cred.discord_user_id, "111222333444555666");
         assert_eq!(cred.anilist_id, 987654321);
+        assert_eq!(cred.anilist_username.as_deref(), Some("AniUser"));
         assert_eq!(cred.access_token, "access_tok");
         assert_eq!(cred.refresh_token.as_deref(), Some("refresh_tok"));
         assert!(cred.token_expires_at.is_some());
@@ -883,7 +898,7 @@ mod tests {
     async fn upsert_updates_existing_credential(pool: Pool<Postgres>) {
         upsert_oauth_credentials(
             "user1",
-            111,
+            linked_account(111, "OldName"),
             "old_token",
             None,
             None,
@@ -904,7 +919,7 @@ mod tests {
 
         upsert_oauth_credentials(
             "user1",
-            111,
+            linked_account(111, "NewName"),
             "new_token",
             Some("new_refresh"),
             None,
@@ -920,6 +935,7 @@ mod tests {
             .expect("credential should exist");
 
         assert_eq!(cred.access_token, "new_token");
+        assert_eq!(cred.anilist_username.as_deref(), Some("NewName"));
         assert_eq!(cred.refresh_token.as_deref(), Some("new_refresh"));
         assert!(cred.relink_required_at.is_none());
         assert!(cred.relink_reason.is_none());
@@ -931,7 +947,7 @@ mod tests {
     async fn fetch_usable_oauth_credential_marks_expired_tokens_for_relink(pool: Pool<Postgres>) {
         upsert_oauth_credentials(
             "expired_user",
-            777,
+            linked_account(777, "ExpiredUser"),
             "expired_access",
             None,
             Some(Utc::now() - Duration::minutes(5)),
@@ -965,7 +981,7 @@ mod tests {
     ) {
         upsert_oauth_credentials(
             "already_flagged_user",
-            778,
+            linked_account(778, "AlreadyFlaggedUser"),
             "expired_access",
             None,
             Some(Utc::now() - Duration::minutes(5)),
@@ -1022,7 +1038,7 @@ mod tests {
     ) {
         upsert_oauth_credentials(
             "race_user",
-            999,
+            linked_account(999, "RaceUser"),
             "fresh_access",
             None,
             Some(Utc::now() + Duration::hours(2)),
@@ -1061,7 +1077,7 @@ mod tests {
     ) {
         upsert_oauth_credentials(
             "already_marked_user",
-            1_000,
+            linked_account(1_000, "AlreadyMarkedUser"),
             "expired_access",
             None,
             Some(Utc::now() - Duration::minutes(5)),
@@ -1120,7 +1136,7 @@ mod tests {
     async fn fetch_usable_oauth_credential_returns_active_credentials(pool: Pool<Postgres>) {
         upsert_oauth_credentials(
             "active_user",
-            888,
+            linked_account(888, "ActiveUser"),
             "active_access",
             None,
             Some(Utc::now() + Duration::hours(6)),
@@ -1155,7 +1171,7 @@ mod tests {
     async fn fetch_by_anilist_id_finds_correct_credential(pool: Pool<Postgres>) {
         upsert_oauth_credentials(
             "user_a",
-            42,
+            linked_account(42, "UserA"),
             "tok_a",
             None,
             None,
@@ -1172,6 +1188,7 @@ mod tests {
 
         assert_eq!(cred.discord_user_id, "user_a");
         assert_eq!(cred.anilist_id, 42);
+        assert_eq!(cred.anilist_username.as_deref(), Some("UserA"));
 
         pool.close().await;
     }
@@ -1191,7 +1208,7 @@ mod tests {
     async fn upsert_rejects_anilist_id_linked_to_another_discord_user(pool: Pool<Postgres>) {
         upsert_oauth_credentials(
             "user_a",
-            42,
+            linked_account(42, "UserA"),
             "tok_a",
             None,
             None,
@@ -1203,7 +1220,7 @@ mod tests {
 
         let error = upsert_oauth_credentials(
             "user_b",
-            42,
+            linked_account(42, "UserB"),
             "tok_b",
             None,
             None,

--- a/src/utils/structs.rs
+++ b/src/utils/structs.rs
@@ -76,6 +76,7 @@ pub struct TokenErrorResponse {
 pub struct OAuthCredential {
     pub discord_user_id: String,
     pub anilist_id: i64,
+    pub anilist_username: Option<String>,
     pub access_token: String,
     pub refresh_token: Option<String>,
     pub token_expires_at: Option<DateTime<Utc>>,
@@ -89,7 +90,11 @@ impl fmt::Debug for OAuthCredential {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("OAuthCredential")
             .field("discord_user_id", &"[REDACTED]")
-            .field("anilist_id", &self.anilist_id)
+            .field("anilist_id", &"[REDACTED]")
+            .field(
+                "anilist_username",
+                &self.anilist_username.as_ref().map(|_| "[REDACTED]"),
+            )
             .field("access_token", &"[REDACTED]")
             .field(
                 "refresh_token",
@@ -139,6 +144,7 @@ pub struct ViewerData {
 #[derive(Deserialize)]
 pub struct Viewer {
     pub id: i64,
+    pub name: String,
 }
 
 /// Carries the Discord user ID recovered from the validated OAuth session.
@@ -221,6 +227,7 @@ mod tests {
         let credential = super::OAuthCredential {
             discord_user_id: "123456789012345678".to_string(),
             anilist_id: 42,
+            anilist_username: Some("AniUser".to_string()),
             access_token: "access_secret".to_string(),
             refresh_token: Some("refresh_secret".to_string()),
             token_expires_at: Some(now),
@@ -235,7 +242,9 @@ mod tests {
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("access_secret"));
         assert!(!debug.contains("refresh_secret"));
+        assert!(!debug.contains("42"));
         assert!(!debug.contains("123456789012345678"));
+        assert!(!debug.contains("AniUser"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Store the AniList username alongside the stable AniList ID in OAuth credentials so linked-account UX can show a friendly display name.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] Chore

## Changes
- e70ea20b5bc2a2cf1a3bb1b40ee6b2afdf69252d: add nullable anilist_username to oauth_credentials, fetch Viewer.name during callback, persist it during credential upsert, redact account-link identifiers from Debug/instrumentation, update OAuth contract docs, and bump auth to 1.1.0

### Notes

Existing linked rows keep working because anilist_username is nullable. They can be populated by a backfill using stored anilist_id values or by users relinking through the OAuth callback.

### High-risk resources

- auth.oauth_credentials schema migration
- AniList OAuth callback persistence path

## Validation

- [x] cargo fmt
- [x] cargo check
- [x] cargo test oauth_credential_debug_redacts_tokens
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [ ] DB integration tests were not run locally because DATABASE_URL is not set

## References

- Companion bot PR updates the read model and linked-account display copy.

---

This PR description was written by Amp.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->