### PR TITLE
[ANNIE-168]/move health readiness endpoints to auth service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ src/
 |- routes/
 |  |- start.rs          # /oauth/anilist/start redirect to AniList OAuth
 |  |- authorized.rs     # /oauth/anilist/callback token exchange + HTML pages
-|  |- healthz.rs        # /healthz dependency-aware health check endpoint
+|  |- healthz.rs        # /healthz liveness and /readyz readiness endpoints
 |  |- catchers.rs       # Custom error catchers (404, etc.)
 |  `- mod.rs
 `- utils/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei-auth"
-version = "2.0.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei-auth"
-version = "1.1.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei-auth"
-version = "2.0.0"
+version = "1.2.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei-auth"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.94"
 publish = false

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # auth
 
-Auth server for AniList OAuth for Annie Mei.
+Auth server for AniList OAuth for Annie Mei. It also owns the HTTP health and readiness endpoints for the Annie Mei stack.
 
 ## Local development
 
 1. Copy `.env.example` to `.env`.
 2. Fill in the AniList OAuth credentials, Postgres connection string, and a Rocket `ROCKET_SECRET_KEY`.
 3. Start the service with `cargo run`.
+4. Verify liveness with `curl http://127.0.0.1:8000/healthz` and readiness with `curl http://127.0.0.1:8000/readyz`.
 
 `SENTRY_DSN` is optional in local development. If it is unset, the service will start without Sentry.
 

--- a/railway.toml
+++ b/railway.toml
@@ -3,7 +3,7 @@ builder = "RAILPACK"
 
 [deploy]
 startCommand = "ROCKET_PORT=$PORT ROCKET_ADDRESS=0.0.0.0 ./bin/annie-mei-auth"
-healthcheckPath = "/healthz"
+healthcheckPath = "/readyz"
 healthcheckTimeout = 60
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 5

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,12 @@ pub mod routes;
 pub mod utils;
 
 use crate::{
-    routes::{authorized::authorized, catchers::not_found, healthz::healthz, start::start},
+    routes::{
+        authorized::authorized,
+        catchers::not_found,
+        healthz::{healthz, readyz},
+        start::start,
+    },
     utils::{
         consts::{ANILIST_TOKEN, ANILIST_USER_BASE},
         structs::MyState,
@@ -184,7 +189,7 @@ async fn build_rocket(config: &AppConfig) -> Result<rocket::Rocket<rocket::Build
     let figment = rocket::Config::figment().merge(("secret_key", config.rocket_secret_key.clone()));
 
     Ok(rocket::custom(figment)
-        .mount("/", routes![healthz, start, authorized])
+        .mount("/", routes![healthz, readyz, start, authorized])
         .mount("/static", FileServer::from(relative!("static")))
         .register("/", catchers![not_found])
         .manage(state))

--- a/src/routes/healthz.rs
+++ b/src/routes/healthz.rs
@@ -33,11 +33,11 @@ async fn check_database(pool: &sqlx::PgPool) -> bool {
     match db_result {
         Ok(Ok(_)) => true,
         Ok(Err(error)) => {
-            tracing::error!(error = %error, "Health check failed for database dependency");
+            error!("Health check failed for database dependency: {error}");
             false
         }
         Err(_) => {
-            tracing::error!("Health check timed out waiting for database dependency");
+            error!("Health check timed out waiting for database dependency");
             false
         }
     }

--- a/src/routes/healthz.rs
+++ b/src/routes/healthz.rs
@@ -8,7 +8,6 @@ use rocket::{
 };
 
 const DATABASE_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Serialize)]
 #[serde(crate = "rocket::serde")]
@@ -20,7 +19,6 @@ pub struct HealthServices<'a> {
 #[serde(crate = "rocket::serde")]
 pub struct HealthResponse<'a> {
     status: &'a str,
-    version: &'a str,
     services: HealthServices<'a>,
 }
 
@@ -64,7 +62,6 @@ fn build_health_response(database_ok: Option<bool>) -> Custom<Json<HealthRespons
         status,
         Json(HealthResponse {
             status: if healthy { "healthy" } else { "unhealthy" },
-            version: VERSION,
             services: HealthServices {
                 database: database_status,
             },
@@ -88,7 +85,7 @@ pub async fn readyz(state: &State<MyState>) -> Custom<Json<HealthResponse<'stati
 
 #[cfg(test)]
 mod tests {
-    use super::{VERSION, build_health_response, healthz, readyz};
+    use super::{build_health_response, healthz, readyz};
     use crate::utils::structs::MyState;
     use rocket::{Config, http::Status, local::asynchronous::Client, routes};
     use serde_json::Value;
@@ -139,7 +136,6 @@ mod tests {
 
         assert_eq!(response.0, Status::Ok);
         assert_eq!(response.1.status, "healthy");
-        assert_eq!(response.1.version, VERSION);
         assert_eq!(response.1.services.database, "not_checked");
     }
 
@@ -149,7 +145,6 @@ mod tests {
 
         assert_eq!(response.0, Status::Ok);
         assert_eq!(response.1.status, "healthy");
-        assert_eq!(response.1.version, VERSION);
         assert_eq!(response.1.services.database, "up");
     }
 
@@ -159,7 +154,6 @@ mod tests {
 
         assert_eq!(response.0, Status::ServiceUnavailable);
         assert_eq!(response.1.status, "unhealthy");
-        assert_eq!(response.1.version, VERSION);
         assert_eq!(response.1.services.database, "down");
     }
 
@@ -175,7 +169,6 @@ mod tests {
             assert_eq!(response.status(), Status::Ok);
             let body = response_json(response).await;
             assert_eq!(body["status"], "healthy");
-            assert_eq!(body["version"], VERSION);
             assert_eq!(body["services"]["database"], "not_checked");
         });
     }
@@ -191,7 +184,6 @@ mod tests {
         assert_eq!(response.status(), Status::Ok);
         let body = response_json(response).await;
         assert_eq!(body["status"], "healthy");
-        assert_eq!(body["version"], VERSION);
         assert_eq!(body["services"]["database"], "up");
 
         drop(client);
@@ -211,7 +203,6 @@ mod tests {
         assert_eq!(response.status(), Status::ServiceUnavailable);
         let body = response_json(response).await;
         assert_eq!(body["status"], "unhealthy");
-        assert_eq!(body["version"], VERSION);
         assert_eq!(body["services"]["database"], "down");
 
         drop(client);

--- a/src/routes/healthz.rs
+++ b/src/routes/healthz.rs
@@ -7,11 +7,12 @@ use rocket::{
     tokio::time::{Duration, timeout},
 };
 
-const HEALTHZ_DATABASE_TIMEOUT: Duration = Duration::from_secs(2);
+const DATABASE_CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[derive(Serialize)]
 #[serde(crate = "rocket::serde")]
-pub struct HealthChecks<'a> {
+pub struct HealthServices<'a> {
     database: &'a str,
 }
 
@@ -19,63 +20,82 @@ pub struct HealthChecks<'a> {
 #[serde(crate = "rocket::serde")]
 pub struct HealthResponse<'a> {
     status: &'a str,
-    checks: HealthChecks<'a>,
+    version: &'a str,
+    services: HealthServices<'a>,
 }
 
-#[get("/healthz")]
-#[tracing::instrument(name = "healthz", skip(state))]
-pub async fn healthz(state: &State<MyState>) -> Custom<Json<HealthResponse<'static>>> {
+#[tracing::instrument(name = "health.database", skip(pool))]
+async fn check_database(pool: &sqlx::PgPool) -> bool {
     let db_result = timeout(
-        HEALTHZ_DATABASE_TIMEOUT,
-        sqlx::query_scalar::<_, i32>("SELECT 1").fetch_one(&state.pool),
+        DATABASE_CHECK_TIMEOUT,
+        sqlx::query_scalar::<_, i32>("SELECT 1").fetch_one(pool),
     )
     .await;
 
     match db_result {
-        Ok(Ok(_)) => Custom(
-            Status::Ok,
-            Json(HealthResponse {
-                status: "healthy",
-                checks: HealthChecks { database: "ok" },
-            }),
-        ),
-        Ok(Err(_)) => {
-            error!("Health check failed for database dependency");
-
-            Custom(
-                Status::ServiceUnavailable,
-                Json(HealthResponse {
-                    status: "unhealthy",
-                    checks: HealthChecks { database: "error" },
-                }),
-            )
+        Ok(Ok(_)) => true,
+        Ok(Err(error)) => {
+            tracing::error!(error = %error, "Health check failed for database dependency");
+            false
         }
         Err(_) => {
-            error!("Health check timed out waiting for database dependency");
-
-            Custom(
-                Status::ServiceUnavailable,
-                Json(HealthResponse {
-                    status: "unhealthy",
-                    checks: HealthChecks { database: "error" },
-                }),
-            )
+            tracing::error!("Health check timed out waiting for database dependency");
+            false
         }
     }
 }
 
+#[tracing::instrument(name = "health.response", skip_all)]
+fn build_health_response(database_ok: Option<bool>) -> Custom<Json<HealthResponse<'static>>> {
+    let healthy = database_ok.unwrap_or(true);
+    let status = if healthy {
+        Status::Ok
+    } else {
+        Status::ServiceUnavailable
+    };
+
+    let database_status = match database_ok {
+        Some(true) => "up",
+        Some(false) => "down",
+        None => "not_checked",
+    };
+
+    Custom(
+        status,
+        Json(HealthResponse {
+            status: if healthy { "healthy" } else { "unhealthy" },
+            version: VERSION,
+            services: HealthServices {
+                database: database_status,
+            },
+        }),
+    )
+}
+
+#[get("/healthz")]
+#[tracing::instrument(name = "healthz")]
+pub async fn healthz() -> Custom<Json<HealthResponse<'static>>> {
+    build_health_response(None)
+}
+
+#[get("/readyz")]
+#[tracing::instrument(name = "readyz", skip(state))]
+pub async fn readyz(state: &State<MyState>) -> Custom<Json<HealthResponse<'static>>> {
+    let database_ok = check_database(&state.pool).await;
+
+    build_health_response(Some(database_ok))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::healthz;
+    use super::{VERSION, build_health_response, healthz, readyz};
     use crate::utils::structs::MyState;
     use rocket::{Config, http::Status, local::asynchronous::Client, routes};
+    use serde_json::Value;
     use sqlx::{Pool, Postgres};
 
-    fn build_test_rocket(pool: Pool<Postgres>) -> rocket::Rocket<rocket::Build> {
-        let figment =
-            Config::figment().merge(("secret_key", "0123456789abcdef0123456789abcdef0123456789A="));
-
-        let state = MyState {
+    fn build_test_state(pool: Pool<Postgres>) -> MyState {
+        MyState {
             client_id: "client-id".to_string(),
             client_secret: "client-secret".to_string(),
             redirect_uri: "http://127.0.0.1:8000/oauth/anilist/callback".to_string(),
@@ -87,50 +107,92 @@ mod tests {
             user_endpoint: "https://graphql.anilist.co".to_string(),
             client: reqwest::Client::new(),
             pool,
-        };
-
-        rocket::custom(figment)
-            .mount("/", routes![healthz])
-            .manage(state)
+        }
     }
 
-    #[sqlx::test(migrations = "./migrations")]
-    async fn healthz_returns_healthy_when_database_is_available(pool: Pool<Postgres>) {
-        let client = Client::tracked(build_test_rocket(pool.clone()))
-            .await
-            .expect("rocket client should build");
+    fn test_figment() -> rocket::figment::Figment {
+        Config::figment().merge(("secret_key", "0123456789abcdef0123456789abcdef0123456789A="))
+    }
 
-        let response = client.get("/healthz").dispatch().await;
+    fn build_healthz_rocket() -> rocket::Rocket<rocket::Build> {
+        rocket::custom(test_figment()).mount("/", routes![healthz])
+    }
 
-        assert_eq!(response.status(), Status::Ok);
+    fn build_test_rocket(pool: Pool<Postgres>) -> rocket::Rocket<rocket::Build> {
+        rocket::custom(test_figment())
+            .mount("/", routes![healthz, readyz])
+            .manage(build_test_state(pool))
+    }
+
+    async fn response_json(response: rocket::local::asynchronous::LocalResponse<'_>) -> Value {
         let body = response
             .into_string()
             .await
             .expect("health endpoint should return body");
-        assert!(body.contains("\"status\":\"healthy\""));
-        assert!(body.contains("\"database\":\"ok\""));
+
+        serde_json::from_str(&body).expect("health endpoint should return JSON")
+    }
+
+    #[test]
+    fn health_response_reports_process_liveness_without_dependency_checks() {
+        let response = build_health_response(None);
+
+        assert_eq!(response.0, Status::Ok);
+        assert_eq!(response.1.status, "healthy");
+        assert_eq!(response.1.version, VERSION);
+        assert_eq!(response.1.services.database, "not_checked");
+    }
+
+    #[test]
+    fn healthz_returns_liveness_shape() {
+        rocket::async_test(async {
+            let client = Client::tracked(build_healthz_rocket())
+                .await
+                .expect("rocket client should build");
+
+            let response = client.get("/healthz").dispatch().await;
+
+            assert_eq!(response.status(), Status::Ok);
+            let body = response_json(response).await;
+            assert_eq!(body["status"], "healthy");
+            assert_eq!(body["version"], VERSION);
+            assert_eq!(body["services"]["database"], "not_checked");
+        });
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn readyz_returns_healthy_when_database_is_available(pool: Pool<Postgres>) {
+        let client = Client::tracked(build_test_rocket(pool.clone()))
+            .await
+            .expect("rocket client should build");
+
+        let response = client.get("/readyz").dispatch().await;
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response_json(response).await;
+        assert_eq!(body["status"], "healthy");
+        assert_eq!(body["version"], VERSION);
+        assert_eq!(body["services"]["database"], "up");
 
         drop(client);
         pool.close().await;
     }
 
     #[sqlx::test(migrations = "./migrations")]
-    async fn healthz_returns_unhealthy_when_database_is_unavailable(pool: Pool<Postgres>) {
+    async fn readyz_returns_unhealthy_when_database_is_unavailable(pool: Pool<Postgres>) {
         let client = Client::tracked(build_test_rocket(pool.clone()))
             .await
             .expect("rocket client should build");
 
         pool.close().await;
 
-        let response = client.get("/healthz").dispatch().await;
+        let response = client.get("/readyz").dispatch().await;
 
         assert_eq!(response.status(), Status::ServiceUnavailable);
-        let body = response
-            .into_string()
-            .await
-            .expect("health endpoint should return body");
-        assert!(body.contains("\"status\":\"unhealthy\""));
-        assert!(body.contains("\"database\":\"error\""));
+        let body = response_json(response).await;
+        assert_eq!(body["status"], "unhealthy");
+        assert_eq!(body["version"], VERSION);
+        assert_eq!(body["services"]["database"], "down");
 
         drop(client);
     }

--- a/src/routes/healthz.rs
+++ b/src/routes/healthz.rs
@@ -144,6 +144,26 @@ mod tests {
     }
 
     #[test]
+    fn ready_response_reports_healthy_when_database_is_up() {
+        let response = build_health_response(Some(true));
+
+        assert_eq!(response.0, Status::Ok);
+        assert_eq!(response.1.status, "healthy");
+        assert_eq!(response.1.version, VERSION);
+        assert_eq!(response.1.services.database, "up");
+    }
+
+    #[test]
+    fn ready_response_reports_unhealthy_when_database_is_down() {
+        let response = build_health_response(Some(false));
+
+        assert_eq!(response.0, Status::ServiceUnavailable);
+        assert_eq!(response.1.status, "unhealthy");
+        assert_eq!(response.1.version, VERSION);
+        assert_eq!(response.1.services.database, "down");
+    }
+
+    #[test]
     fn healthz_returns_liveness_shape() {
         rocket::async_test(async {
             let client = Client::tracked(build_healthz_rocket())


### PR DESCRIPTION
## Summary

Move stack health/readiness responsibility into the auth service by making `/healthz` a liveness endpoint and adding `/readyz` for database readiness.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore

## Changes
- df9f70b42797f594e660fde2edeae10782facba2: added auth `/readyz`, changed `/healthz` to dependency-free liveness, and mounted both routes
- e80f83dc7078172fa5d3a748a77d7dda32a1893b: documented auth health and readiness endpoints
- bf9e6bc5539c722de98fa759985e01033053ab23: pointed the platform health check at `/readyz`
- 5cd4d6788f5d5bd1cf10f7981ca39114053cd3c5: added tests for liveness and readiness response shapes
- 0afbb701b623290a4423e81f424a3cdbe9c352ea: set the auth release bump to minor version 1.2.0 for the new readiness endpoint

### Notes

Use `/healthz` for process liveness and `/readyz` for dependency-aware readiness.

## Validation
- [x] cargo fmt --check
- [x] cargo check
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] cargo test response_reports -- --nocapture
- [x] cargo test routes::healthz::tests::healthz_returns_liveness_shape -- --nocapture

---

This PR description was written by GPT-5.
