### PR TITLE
[ANNIE-189]/separate auth database schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "annie-mei-auth"
-version = "1.2.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "annie-mei-auth"
-version = "1.2.1"
+version = "2.0.0"
 edition = "2024"
 rust-version = "1.95"
 publish = false

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Auth server for AniList OAuth for Annie Mei. It also owns the HTTP health and re
 ## Documentation
 
 - [OAuth data contract](docs/oauth-contract.md) — shared schema and payload contract with the [`annie-mei`](https://github.com/annie-mei/annie-mei) bot repo
+- [Database schema ownership](docs/database-schemas.md) — shared Postgres schemas, migration isolation, grants, and deployment order
 
 ## Validation
 

--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -1,0 +1,97 @@
+# Database schema ownership
+
+The auth-service and Annie Mei bot share one Postgres database but own separate schemas so their SQLx migration histories do not conflict.
+
+| Schema | Owner | Tables |
+| --- | --- | --- |
+| `auth` | auth-service | `oauth_credentials`, `oauth_sessions` |
+| `annie_mei` | Annie Mei bot | `user_settings`, `guild_settings` |
+
+Runtime queries should use schema-qualified table names. Do not rely on `search_path` for application reads or writes.
+
+## Auth-service migrations
+
+Auth-service startup ensures the `auth` schema exists, then runs SQLx migrations with the migration connection `search_path` set to `auth,public`. SQLx therefore creates and reads `auth._sqlx_migrations`.
+
+Auth-service migrations define auth-owned tables directly in the `auth` schema. They do not move legacy `public` tables or preserve old `public._sqlx_migrations` state. The ANNIE-189 deployment is a major-version schema reset: existing OAuth rows must be re-created by users running `/register` again after deploy.
+
+For a clean cutover, remove old app-owned public tables and SQLx history before deploying the new auth-service:
+
+```sql
+DROP TABLE IF EXISTS public.oauth_sessions CASCADE;
+DROP TABLE IF EXISTS public.oauth_credentials CASCADE;
+DROP TABLE IF EXISTS public._sqlx_migrations CASCADE;
+
+DROP TABLE IF EXISTS auth.oauth_sessions CASCADE;
+DROP TABLE IF EXISTS auth.oauth_credentials CASCADE;
+DROP TABLE IF EXISTS auth._sqlx_migrations CASCADE;
+
+CREATE SCHEMA IF NOT EXISTS auth;
+CREATE SCHEMA IF NOT EXISTS annie_mei;
+```
+
+After the reset, auth-service startup recreates `auth.oauth_credentials`, `auth.oauth_sessions`, and `auth._sqlx_migrations` from the checked-in migrations.
+
+## Annie Mei bot schema
+
+The bot owns `annie_mei.user_settings` and `annie_mei.guild_settings`. Until the bot runs SQLx migrations at startup, create those tables manually during the cutover or run the bot migrations with the intended schema context.
+
+```sql
+CREATE SCHEMA IF NOT EXISTS annie_mei;
+
+CREATE TABLE IF NOT EXISTS annie_mei.user_settings (
+    discord_user_id TEXT NOT NULL,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (discord_user_id, setting_key)
+);
+
+CREATE TABLE IF NOT EXISTS annie_mei.guild_settings (
+    guild_id TEXT NOT NULL,
+    setting_key TEXT NOT NULL,
+    setting_value TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (guild_id, setting_key)
+);
+```
+
+## Permissions
+
+The auth-service database role should own or fully manage objects in `auth`.
+
+The Annie Mei database role needs cross-schema access for account-link commands:
+
+```sql
+GRANT USAGE ON SCHEMA auth TO annie_mei_bot;
+GRANT SELECT, DELETE ON auth.oauth_credentials TO annie_mei_bot;
+GRANT SELECT, DELETE ON auth.oauth_sessions TO annie_mei_bot;
+```
+
+The Annie Mei role also needs read/write access to its own schema:
+
+```sql
+GRANT USAGE ON SCHEMA annie_mei TO annie_mei_bot;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA annie_mei TO annie_mei_bot;
+```
+
+Use the real runtime role name for each environment. In local/Supabase development this may be `annie` instead of `annie_mei_bot`.
+
+## Deployment order
+
+1. Stop old auth-service and bot instances.
+2. Back up the database if any data should be recoverable.
+3. Run the destructive reset SQL above for legacy OAuth tables and SQLx history.
+4. Deploy auth-service so startup creates fresh `auth.*` tables and `auth._sqlx_migrations`.
+5. Create or migrate bot-owned `annie_mei.*` settings tables.
+6. Grant cross-schema permissions for the runtime roles.
+7. Deploy Annie Mei bot code that reads `auth.*` and writes `annie_mei.*`.
+8. Re-run `/register` for affected users because OAuth credentials were reset.
+
+Avoid public compatibility views for this cutover. They can confuse schema checks and do not safely cover old write paths such as OAuth upserts.
+
+## Rollback
+
+This cutover is destructive for OAuth rows. Roll back application code by redeploying the prior versions and restoring a database backup if the old rows are needed.

--- a/docs/oauth-contract.md
+++ b/docs/oauth-contract.md
@@ -24,11 +24,11 @@ The bot mirrors this document at
                        │ /oauth/anilist  │        │ /oauth/anilist   │
                        │   /start        │        │   /callback      │
                        ╰────────┬────────╯        ╰────────┬─────────╯
-                                │ writes oauth_sessions    │ writes oauth_credentials
+                                 │ writes auth.oauth_sessions │ writes auth.oauth_credentials
                                 ▼                          ▼
                        ╭──────────────────────────────────────────╮
-                       │              Postgres (shared)           │
-                       │  oauth_sessions      oauth_credentials   │
+                        │              Postgres (shared)           │
+                        │ auth.oauth_sessions  auth.oauth_credentials │
                        ╰──────────────────────────────────────────╯
                                                 ▲
                                                 │ reads (whoami, guild overlay)
@@ -36,13 +36,15 @@ The bot mirrors this document at
                                           Annie Mei bot
 ```
 
-The auth-service owns both `oauth_credentials` and `oauth_sessions`.
-The bot reads/deletes those rows directly via raw SQL using the same
-shared Postgres database — it has no Diesel-managed tables of its own.
+The auth-service owns both `auth.oauth_credentials` and
+`auth.oauth_sessions`. The bot reads/deletes those rows directly via raw
+SQL using the same shared Postgres database. Bot-owned settings tables
+live in the `annie_mei` schema. Schema ownership and migration isolation
+are documented in [Database schema ownership](database-schemas.md).
 
 ## Tables
 
-### `oauth_credentials`
+### `auth.oauth_credentials`
 
 Source of truth for **linked** AniList accounts. Migrations live in
 [`migrations/20260328000001_create_oauth_credentials.up.sql`](../migrations/20260328000001_create_oauth_credentials.up.sql)
@@ -84,7 +86,7 @@ per-guild MediaList overlay) in
 same transaction as `oauth_sessions`
 (`annie-mei/src/commands/unregister.rs`).
 
-### `oauth_sessions`
+### `auth.oauth_sessions`
 
 Short-lived state for in-flight OAuth flows. Migration:
 [`migrations/20260328000002_create_oauth_sessions.up.sql`](../migrations/20260328000002_create_oauth_sessions.up.sql).
@@ -92,7 +94,7 @@ Short-lived state for in-flight OAuth flows. Migration:
 | Column            | Type           | Notes                                                                       |
 | ----------------- | -------------- | --------------------------------------------------------------------------- |
 | `state`           | `TEXT` (PK)    | Opaque per-flow state token issued by this service.                         |
-| `discord_user_id` | `TEXT`         | Raw Discord snowflake string, mirroring `oauth_credentials.discord_user_id`. |
+| `discord_user_id` | `TEXT`         | Raw Discord snowflake string, mirroring `auth.oauth_credentials.discord_user_id`. |
 | `expires_at`      | `TIMESTAMPTZ`  | When the session token stops being valid.                                   |
 | `used_at`         | `TIMESTAMPTZ NULL` | When the session was redeemed (replay protection).                          |
 | `created_at`      | `TIMESTAMPTZ`  | Initial creation time.                                                      |
@@ -102,7 +104,7 @@ redirecting the user to AniList; `/oauth/anilist/callback` marks
 `used_at` to enforce single-use.
 
 **Bot deletes:** `/unregister` includes
-`DELETE FROM oauth_sessions WHERE discord_user_id = $1` in the same
+`DELETE FROM auth.oauth_sessions WHERE discord_user_id = $1` in the same
 transaction so half-finished flows do not linger after a user unlinks.
 
 ## OAuth context payload
@@ -131,7 +133,7 @@ The signature segment is appended after `.` to form
 Make the matching change in both repos in the same release window if
 you touch any of the following:
 
-- A column on `oauth_credentials` or `oauth_sessions` (rename, type
+- A column on `auth.oauth_credentials` or `auth.oauth_sessions` (rename, type
   change, deletion, or new NOT NULL column).
 - The `discord_user_id` representation (it must stay the raw Discord
   snowflake stringified via `user.id.get().to_string()` so bot
@@ -149,10 +151,10 @@ When making one of those changes:
 
 ## Privacy
 
-`oauth_credentials.discord_user_id` and `oauth_sessions.discord_user_id`
+`auth.oauth_credentials.discord_user_id` and `auth.oauth_sessions.discord_user_id`
 intentionally store the raw Discord snowflake so that `/register`,
 `/whoami`, and `/unregister` can all match on the same value. The
-`oauth_credentials.anilist_id` and `oauth_credentials.anilist_username`
+`auth.oauth_credentials.anilist_id` and `auth.oauth_credentials.anilist_username`
 fields are also user-identifying account-linkage data. **Logs, spans,
 metrics labels, breadcrumbs, and Sentry telemetry must not include any
 of those raw identifiers.** Use
@@ -172,12 +174,12 @@ Sentry transactions, request breadcrumbs, distributed tracing spans, and
 any reverse-proxy logs before those observability records leave the
 service.
 
-`oauth_credentials.access_token` and `oauth_credentials.refresh_token`
+`auth.oauth_credentials.access_token` and `auth.oauth_credentials.refresh_token`
 are bearer credentials that grant full access to the linked AniList
 account. **They must never appear in logs, spans, breadcrumbs, error
 payloads, Sentry events, or any other observability sink — not in
 plain text and not as a fingerprint.** When propagating an
-`oauth_credentials` row through code that might be serialised by an
+`auth.oauth_credentials` row through code that might be serialised by an
 error handler or panic hook, redact both fields first or move them
 behind a wrapper type whose `Debug`/`Display` impls do not expose the
 secret. The same rule applies to AniList's response bodies for

--- a/migrations/20260328000001_create_oauth_credentials.down.sql
+++ b/migrations/20260328000001_create_oauth_credentials.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS oauth_credentials;
+DROP TABLE IF EXISTS auth.oauth_credentials;

--- a/migrations/20260328000001_create_oauth_credentials.up.sql
+++ b/migrations/20260328000001_create_oauth_credentials.up.sql
@@ -1,4 +1,6 @@
-CREATE TABLE IF NOT EXISTS oauth_credentials (
+CREATE SCHEMA IF NOT EXISTS auth;
+
+CREATE TABLE IF NOT EXISTS auth.oauth_credentials (
     discord_user_id    TEXT        PRIMARY KEY,
     anilist_id         BIGINT      NOT NULL,
     access_token       TEXT        NOT NULL,

--- a/migrations/20260328000002_create_oauth_sessions.down.sql
+++ b/migrations/20260328000002_create_oauth_sessions.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS oauth_sessions;
+DROP TABLE IF EXISTS auth.oauth_sessions;

--- a/migrations/20260328000002_create_oauth_sessions.up.sql
+++ b/migrations/20260328000002_create_oauth_sessions.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS oauth_sessions (
+CREATE TABLE IF NOT EXISTS auth.oauth_sessions (
     state           TEXT        PRIMARY KEY,
     discord_user_id TEXT        NOT NULL,
     expires_at      TIMESTAMPTZ NOT NULL,

--- a/migrations/20260401000003_add_oauth_credential_relink_fields.down.sql
+++ b/migrations/20260401000003_add_oauth_credential_relink_fields.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE oauth_credentials
+ALTER TABLE auth.oauth_credentials
 DROP COLUMN IF EXISTS relink_reason,
 DROP COLUMN IF EXISTS relink_required_at;

--- a/migrations/20260401000003_add_oauth_credential_relink_fields.up.sql
+++ b/migrations/20260401000003_add_oauth_credential_relink_fields.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE oauth_credentials
+ALTER TABLE auth.oauth_credentials
 ADD COLUMN IF NOT EXISTS relink_required_at TIMESTAMPTZ,
 ADD COLUMN IF NOT EXISTS relink_reason TEXT;

--- a/migrations/20260505000001_add_anilist_username_to_oauth_credentials.down.sql
+++ b/migrations/20260505000001_add_anilist_username_to_oauth_credentials.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE oauth_credentials
-DROP COLUMN anilist_username;
+ALTER TABLE auth.oauth_credentials
+DROP COLUMN IF EXISTS anilist_username;

--- a/migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql
+++ b/migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE oauth_credentials
-ADD COLUMN anilist_username TEXT NULL;
+ALTER TABLE auth.oauth_credentials
+ADD COLUMN IF NOT EXISTS anilist_username TEXT NULL;

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,14 +18,14 @@ use crate::{
 use rocket::fs::{FileServer, relative};
 
 use anyhow::{Context, Result};
-use sqlx::postgres::PgPoolOptions;
+use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use std::env;
+use std::str::FromStr;
 use std::sync::Arc;
 use tracing_subscriber::prelude::*;
 
 const DEFAULT_CONTEXT_TTL_SECONDS: i64 = 300;
 const DEFAULT_STATE_TTL_SECONDS: i64 = 300;
-
 struct AppConfig {
     sentry_dsn: Option<String>,
     sentry_environment: Option<String>,
@@ -151,6 +151,15 @@ fn init_sentry(
     ))
 }
 
+async fn prepare_auth_schema(pool: &sqlx::PgPool) -> Result<()> {
+    sqlx::query("CREATE SCHEMA IF NOT EXISTS auth")
+        .execute(pool)
+        .await
+        .context("Failed to create auth schema")?;
+
+    Ok(())
+}
+
 async fn build_rocket(config: &AppConfig) -> Result<rocket::Rocket<rocket::Build>> {
     let pool = PgPoolOptions::new()
         .max_connections(5)
@@ -158,10 +167,22 @@ async fn build_rocket(config: &AppConfig) -> Result<rocket::Rocket<rocket::Build
         .await
         .context("Failed to connect to the database")?;
 
+    prepare_auth_schema(&pool).await?;
+
+    let migration_options = PgConnectOptions::from_str(&config.database_url)
+        .context("Failed to parse database URL")?
+        .options([("search_path", "auth,public")]);
+    let migration_pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect_with(migration_options)
+        .await
+        .context("Failed to connect to the auth migration database")?;
+
     sqlx::migrate!("./migrations")
-        .run(&pool)
+        .run(&migration_pool)
         .await
         .context("Failed to run database migrations")?;
+    migration_pool.close().await;
 
     let client = reqwest::Client::builder()
         .user_agent(concat!(

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -326,7 +326,7 @@ pub async fn upsert_oauth_credentials(
     }
 
     sqlx::query(
-        "INSERT INTO oauth_credentials \
+        "INSERT INTO auth.oauth_credentials \
          (discord_user_id, anilist_id, anilist_username, access_token, refresh_token, token_expires_at, token_updated_at) \
          VALUES ($1, $2, $3, $4, $5, $6, NOW()) \
          ON CONFLICT (discord_user_id) DO UPDATE SET \
@@ -385,7 +385,7 @@ async fn mark_expired_oauth_credential_relink_required(
     );
 
     sqlx::query(
-        "UPDATE oauth_credentials \
+        "UPDATE auth.oauth_credentials \
          SET relink_required_at = NOW(), relink_reason = $2 \
          WHERE discord_user_id = $1 \
            AND relink_required_at IS NULL \
@@ -424,7 +424,7 @@ pub async fn mark_oauth_credentials_relink_required(
     );
 
     sqlx::query(
-        "UPDATE oauth_credentials \
+        "UPDATE auth.oauth_credentials \
          SET relink_required_at = NOW(), relink_reason = $2 \
          WHERE discord_user_id = $1",
     )
@@ -463,7 +463,7 @@ pub async fn fetch_credential_by_discord_user(
     sqlx::query_as::<_, OAuthCredential>(
         "SELECT discord_user_id, anilist_id, anilist_username, access_token, refresh_token, \
          token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
-         FROM oauth_credentials WHERE discord_user_id = $1",
+         FROM auth.oauth_credentials WHERE discord_user_id = $1",
     )
     .bind(discord_user_id)
     .fetch_optional(db)
@@ -490,7 +490,7 @@ pub async fn fetch_credential_by_anilist_id(
     sqlx::query_as::<_, OAuthCredential>(
         "SELECT discord_user_id, anilist_id, anilist_username, access_token, refresh_token, \
          token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
-         FROM oauth_credentials WHERE anilist_id = $1",
+         FROM auth.oauth_credentials WHERE anilist_id = $1",
     )
     .bind(anilist_id)
     .fetch_optional(db)
@@ -657,7 +657,7 @@ pub async fn insert_oauth_session(
     );
 
     sqlx::query(
-        "INSERT INTO oauth_sessions (state, discord_user_id, expires_at) \
+        "INSERT INTO auth.oauth_sessions (state, discord_user_id, expires_at) \
          VALUES ($1, $2, NOW() + ($3 * INTERVAL '1 second'))",
     )
     .bind(state)
@@ -682,7 +682,7 @@ pub async fn consume_oauth_session(
     db: &Pool<Postgres>,
 ) -> Result<OAuthSession, SessionConsumeError> {
     let session = sqlx::query_as::<_, OAuthSession>(
-        "UPDATE oauth_sessions \
+        "UPDATE auth.oauth_sessions \
          SET used_at = NOW() \
          WHERE state = $1 AND used_at IS NULL AND expires_at > NOW() \
          RETURNING state, discord_user_id, expires_at, used_at, created_at",
@@ -701,11 +701,12 @@ pub async fn consume_oauth_session(
         used_at: Option<DateTime<Utc>>,
     }
 
-    let diag = sqlx::query_as::<_, Diag>("SELECT used_at FROM oauth_sessions WHERE state = $1")
-        .bind(state_val)
-        .fetch_optional(db)
-        .await
-        .map_err(SessionConsumeError::Db)?;
+    let diag =
+        sqlx::query_as::<_, Diag>("SELECT used_at FROM auth.oauth_sessions WHERE state = $1")
+            .bind(state_val)
+            .fetch_optional(db)
+            .await
+            .map_err(SessionConsumeError::Db)?;
 
     match diag {
         None => Err(SessionConsumeError::NotFound),
@@ -1292,7 +1293,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn consume_session_fails_for_expired_state(pool: Pool<Postgres>) {
         sqlx::query(
-            "INSERT INTO oauth_sessions (state, discord_user_id, expires_at) \
+            "INSERT INTO auth.oauth_sessions (state, discord_user_id, expires_at) \
              VALUES ($1, $2, NOW() - INTERVAL '1 minute')",
         )
         .bind("expired_state")


### PR DESCRIPTION
## Summary

Move auth-owned OAuth storage into the `auth` schema using a deliberate major-version reset. Runtime SQL is schema-qualified, migrations create `auth.*` objects directly, and startup creates the `auth` schema before SQLx writes migration history to `auth._sqlx_migrations`.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [x] Documentation
- [x] Chore

## Changes
- 950a11889773107f4b851ad6f60d3136a660475d: schema-qualify auth runtime SQL, create OAuth tables directly under `auth`, and run migrations against `auth._sqlx_migrations`
- 4380ec70eea909beb940a37a23617f9e17a02ba5: document the destructive auth schema reset, deployment order, permissions, and OAuth contract updates
- 9140fcab9e3e70537339d447081e80eab028599e: bump auth service to `2.0.0` for the breaking schema reset

### Notes

ANNIE-189 is now intentionally a destructive auth database reset instead of a data-preserving table move. Deployment should drop legacy `public.oauth_credentials`, `public.oauth_sessions`, and old SQLx migration history before starting the new auth-service. The service then recreates fresh `auth.oauth_credentials`, `auth.oauth_sessions`, and `auth._sqlx_migrations` from checked-in migrations.

OAuth rows are not preserved. Affected users need to run `/register` again after deploy. This avoids migration-history seeding, checksum mismatches, and table-move edge cases.

### High-risk resources

- PostgreSQL schemas: `public`, `auth`, `annie_mei`
- New auth-owned tables: `auth.oauth_credentials`, `auth.oauth_sessions`
- Legacy reset targets: `public.oauth_credentials`, `public.oauth_sessions`, `public._sqlx_migrations`
- Migration history: `auth._sqlx_migrations`

## Validation
- [x] cargo fmt --check
- [x] cargo test, 60 tests
- [x] cargo clippy --all-targets --all-features -- -D warnings
- [x] Fresh local Postgres runtime smoke test: auth-service created schema/migration state and launched Rocket on a temporary database
- [x] Local reset rehearsal on `annie_mei_dev`: dropped legacy OAuth tables/history, then auth-service recreated clean `auth.*` state and launched Rocket
- [x] Simplify review pass completed with no blockers; removed redundant schema creation from the second migration

## References

---

This PR description was written by gpt-5.5.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/30" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
