### PR TITLE
[ANNIE-189]/avoid Supabase auth schema collision

### DIFF
--- a/docs/database-schemas.md
+++ b/docs/database-schemas.md
@@ -4,16 +4,16 @@ The auth-service and Annie Mei bot share one Postgres database but own separate 
 
 | Schema | Owner | Tables |
 | --- | --- | --- |
-| `auth` | auth-service | `oauth_credentials`, `oauth_sessions` |
+| `annie_auth` | auth-service | `oauth_credentials`, `oauth_sessions` |
 | `annie_mei` | Annie Mei bot | `user_settings`, `guild_settings` |
 
 Runtime queries should use schema-qualified table names. Do not rely on `search_path` for application reads or writes.
 
 ## Auth-service migrations
 
-Auth-service startup ensures the `auth` schema exists, then runs SQLx migrations with the migration connection `search_path` set to `auth,public`. SQLx therefore creates and reads `auth._sqlx_migrations`.
+Auth-service startup ensures the `annie_auth` schema exists, then runs SQLx migrations with the migration connection `search_path` set to `annie_auth,public`. SQLx therefore creates and reads `annie_auth._sqlx_migrations`.
 
-Auth-service migrations define auth-owned tables directly in the `auth` schema. They do not move legacy `public` tables or preserve old `public._sqlx_migrations` state. The ANNIE-189 deployment is a major-version schema reset: existing OAuth rows must be re-created by users running `/register` again after deploy.
+Auth-service migrations define auth-owned tables directly in the `annie_auth` schema. They do not move legacy `public` tables or preserve old `public._sqlx_migrations` state. The ANNIE-189 deployment is a major-version schema reset: existing OAuth rows must be re-created by users running `/register` again after deploy.
 
 For a clean cutover, remove old app-owned public tables and SQLx history before deploying the new auth-service:
 
@@ -22,15 +22,15 @@ DROP TABLE IF EXISTS public.oauth_sessions CASCADE;
 DROP TABLE IF EXISTS public.oauth_credentials CASCADE;
 DROP TABLE IF EXISTS public._sqlx_migrations CASCADE;
 
-DROP TABLE IF EXISTS auth.oauth_sessions CASCADE;
-DROP TABLE IF EXISTS auth.oauth_credentials CASCADE;
-DROP TABLE IF EXISTS auth._sqlx_migrations CASCADE;
+DROP TABLE IF EXISTS annie_auth.oauth_sessions CASCADE;
+DROP TABLE IF EXISTS annie_auth.oauth_credentials CASCADE;
+DROP TABLE IF EXISTS annie_auth._sqlx_migrations CASCADE;
 
-CREATE SCHEMA IF NOT EXISTS auth;
+CREATE SCHEMA IF NOT EXISTS annie_auth;
 CREATE SCHEMA IF NOT EXISTS annie_mei;
 ```
 
-After the reset, auth-service startup recreates `auth.oauth_credentials`, `auth.oauth_sessions`, and `auth._sqlx_migrations` from the checked-in migrations.
+After the reset, auth-service startup recreates `annie_auth.oauth_credentials`, `annie_auth.oauth_sessions`, and `annie_auth._sqlx_migrations` from the checked-in migrations.
 
 ## Annie Mei bot schema
 
@@ -60,14 +60,14 @@ CREATE TABLE IF NOT EXISTS annie_mei.guild_settings (
 
 ## Permissions
 
-The auth-service database role should own or fully manage objects in `auth`.
+The auth-service database role should own or fully manage objects in `annie_auth`.
 
 The Annie Mei database role needs cross-schema access for account-link commands:
 
 ```sql
-GRANT USAGE ON SCHEMA auth TO annie_mei_bot;
-GRANT SELECT, DELETE ON auth.oauth_credentials TO annie_mei_bot;
-GRANT SELECT, DELETE ON auth.oauth_sessions TO annie_mei_bot;
+GRANT USAGE ON SCHEMA annie_auth TO annie_mei_bot;
+GRANT SELECT, DELETE ON annie_auth.oauth_credentials TO annie_mei_bot;
+GRANT SELECT, DELETE ON annie_auth.oauth_sessions TO annie_mei_bot;
 ```
 
 The Annie Mei role also needs read/write access to its own schema:
@@ -84,10 +84,10 @@ Use the real runtime role name for each environment. In local/Supabase developme
 1. Stop old auth-service and bot instances.
 2. Back up the database if any data should be recoverable.
 3. Run the destructive reset SQL above for legacy OAuth tables and SQLx history.
-4. Deploy auth-service so startup creates fresh `auth.*` tables and `auth._sqlx_migrations`.
+4. Deploy auth-service so startup creates fresh `annie_auth.*` tables and `annie_auth._sqlx_migrations`.
 5. Create or migrate bot-owned `annie_mei.*` settings tables.
 6. Grant cross-schema permissions for the runtime roles.
-7. Deploy Annie Mei bot code that reads `auth.*` and writes `annie_mei.*`.
+7. Deploy Annie Mei bot code that reads `annie_auth.*` and writes `annie_mei.*`.
 8. Re-run `/register` for affected users because OAuth credentials were reset.
 
 Avoid public compatibility views for this cutover. They can confuse schema checks and do not safely cover old write paths such as OAuth upserts.

--- a/docs/oauth-contract.md
+++ b/docs/oauth-contract.md
@@ -24,11 +24,11 @@ The bot mirrors this document at
                        │ /oauth/anilist  │        │ /oauth/anilist   │
                        │   /start        │        │   /callback      │
                        ╰────────┬────────╯        ╰────────┬─────────╯
-                                 │ writes auth.oauth_sessions │ writes auth.oauth_credentials
+                                 │ writes annie_auth.oauth_sessions │ writes annie_auth.oauth_credentials
                                 ▼                          ▼
                        ╭──────────────────────────────────────────╮
                         │              Postgres (shared)           │
-                        │ auth.oauth_sessions  auth.oauth_credentials │
+                        │ annie_auth.oauth_sessions  annie_auth.oauth_credentials │
                        ╰──────────────────────────────────────────╯
                                                 ▲
                                                 │ reads (whoami, guild overlay)
@@ -36,15 +36,15 @@ The bot mirrors this document at
                                           Annie Mei bot
 ```
 
-The auth-service owns both `auth.oauth_credentials` and
-`auth.oauth_sessions`. The bot reads/deletes those rows directly via raw
+The auth-service owns both `annie_auth.oauth_credentials` and
+`annie_auth.oauth_sessions`. The bot reads/deletes those rows directly via raw
 SQL using the same shared Postgres database. Bot-owned settings tables
 live in the `annie_mei` schema. Schema ownership and migration isolation
 are documented in [Database schema ownership](database-schemas.md).
 
 ## Tables
 
-### `auth.oauth_credentials`
+### `annie_auth.oauth_credentials`
 
 Source of truth for **linked** AniList accounts. Migrations live in
 [`migrations/20260328000001_create_oauth_credentials.up.sql`](../migrations/20260328000001_create_oauth_credentials.up.sql)
@@ -86,7 +86,7 @@ per-guild MediaList overlay) in
 same transaction as `oauth_sessions`
 (`annie-mei/src/commands/unregister.rs`).
 
-### `auth.oauth_sessions`
+### `annie_auth.oauth_sessions`
 
 Short-lived state for in-flight OAuth flows. Migration:
 [`migrations/20260328000002_create_oauth_sessions.up.sql`](../migrations/20260328000002_create_oauth_sessions.up.sql).
@@ -94,7 +94,7 @@ Short-lived state for in-flight OAuth flows. Migration:
 | Column            | Type           | Notes                                                                       |
 | ----------------- | -------------- | --------------------------------------------------------------------------- |
 | `state`           | `TEXT` (PK)    | Opaque per-flow state token issued by this service.                         |
-| `discord_user_id` | `TEXT`         | Raw Discord snowflake string, mirroring `auth.oauth_credentials.discord_user_id`. |
+| `discord_user_id` | `TEXT`         | Raw Discord snowflake string, mirroring `annie_auth.oauth_credentials.discord_user_id`. |
 | `expires_at`      | `TIMESTAMPTZ`  | When the session token stops being valid.                                   |
 | `used_at`         | `TIMESTAMPTZ NULL` | When the session was redeemed (replay protection).                          |
 | `created_at`      | `TIMESTAMPTZ`  | Initial creation time.                                                      |
@@ -104,7 +104,7 @@ redirecting the user to AniList; `/oauth/anilist/callback` marks
 `used_at` to enforce single-use.
 
 **Bot deletes:** `/unregister` includes
-`DELETE FROM auth.oauth_sessions WHERE discord_user_id = $1` in the same
+`DELETE FROM annie_auth.oauth_sessions WHERE discord_user_id = $1` in the same
 transaction so half-finished flows do not linger after a user unlinks.
 
 ## OAuth context payload
@@ -133,7 +133,7 @@ The signature segment is appended after `.` to form
 Make the matching change in both repos in the same release window if
 you touch any of the following:
 
-- A column on `auth.oauth_credentials` or `auth.oauth_sessions` (rename, type
+- A column on `annie_auth.oauth_credentials` or `annie_auth.oauth_sessions` (rename, type
   change, deletion, or new NOT NULL column).
 - The `discord_user_id` representation (it must stay the raw Discord
   snowflake stringified via `user.id.get().to_string()` so bot
@@ -151,10 +151,10 @@ When making one of those changes:
 
 ## Privacy
 
-`auth.oauth_credentials.discord_user_id` and `auth.oauth_sessions.discord_user_id`
+`annie_auth.oauth_credentials.discord_user_id` and `annie_auth.oauth_sessions.discord_user_id`
 intentionally store the raw Discord snowflake so that `/register`,
 `/whoami`, and `/unregister` can all match on the same value. The
-`auth.oauth_credentials.anilist_id` and `auth.oauth_credentials.anilist_username`
+`annie_auth.oauth_credentials.anilist_id` and `annie_auth.oauth_credentials.anilist_username`
 fields are also user-identifying account-linkage data. **Logs, spans,
 metrics labels, breadcrumbs, and Sentry telemetry must not include any
 of those raw identifiers.** Use
@@ -174,12 +174,12 @@ Sentry transactions, request breadcrumbs, distributed tracing spans, and
 any reverse-proxy logs before those observability records leave the
 service.
 
-`auth.oauth_credentials.access_token` and `auth.oauth_credentials.refresh_token`
+`annie_auth.oauth_credentials.access_token` and `annie_auth.oauth_credentials.refresh_token`
 are bearer credentials that grant full access to the linked AniList
 account. **They must never appear in logs, spans, breadcrumbs, error
 payloads, Sentry events, or any other observability sink — not in
 plain text and not as a fingerprint.** When propagating an
-`auth.oauth_credentials` row through code that might be serialised by an
+`annie_auth.oauth_credentials` row through code that might be serialised by an
 error handler or panic hook, redact both fields first or move them
 behind a wrapper type whose `Debug`/`Display` impls do not expose the
 secret. The same rule applies to AniList's response bodies for

--- a/migrations/20260328000001_create_oauth_credentials.down.sql
+++ b/migrations/20260328000001_create_oauth_credentials.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS auth.oauth_credentials;
+DROP TABLE IF EXISTS annie_auth.oauth_credentials;

--- a/migrations/20260328000001_create_oauth_credentials.up.sql
+++ b/migrations/20260328000001_create_oauth_credentials.up.sql
@@ -1,6 +1,6 @@
-CREATE SCHEMA IF NOT EXISTS auth;
+CREATE SCHEMA IF NOT EXISTS annie_auth;
 
-CREATE TABLE IF NOT EXISTS auth.oauth_credentials (
+CREATE TABLE IF NOT EXISTS annie_auth.oauth_credentials (
     discord_user_id    TEXT        PRIMARY KEY,
     anilist_id         BIGINT      NOT NULL,
     access_token       TEXT        NOT NULL,

--- a/migrations/20260328000002_create_oauth_sessions.down.sql
+++ b/migrations/20260328000002_create_oauth_sessions.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS auth.oauth_sessions;
+DROP TABLE IF EXISTS annie_auth.oauth_sessions;

--- a/migrations/20260328000002_create_oauth_sessions.up.sql
+++ b/migrations/20260328000002_create_oauth_sessions.up.sql
@@ -1,4 +1,4 @@
-CREATE TABLE IF NOT EXISTS auth.oauth_sessions (
+CREATE TABLE IF NOT EXISTS annie_auth.oauth_sessions (
     state           TEXT        PRIMARY KEY,
     discord_user_id TEXT        NOT NULL,
     expires_at      TIMESTAMPTZ NOT NULL,

--- a/migrations/20260401000003_add_oauth_credential_relink_fields.down.sql
+++ b/migrations/20260401000003_add_oauth_credential_relink_fields.down.sql
@@ -1,3 +1,3 @@
-ALTER TABLE auth.oauth_credentials
+ALTER TABLE annie_auth.oauth_credentials
 DROP COLUMN IF EXISTS relink_reason,
 DROP COLUMN IF EXISTS relink_required_at;

--- a/migrations/20260401000003_add_oauth_credential_relink_fields.up.sql
+++ b/migrations/20260401000003_add_oauth_credential_relink_fields.up.sql
@@ -1,3 +1,3 @@
-ALTER TABLE auth.oauth_credentials
+ALTER TABLE annie_auth.oauth_credentials
 ADD COLUMN IF NOT EXISTS relink_required_at TIMESTAMPTZ,
 ADD COLUMN IF NOT EXISTS relink_reason TEXT;

--- a/migrations/20260505000001_add_anilist_username_to_oauth_credentials.down.sql
+++ b/migrations/20260505000001_add_anilist_username_to_oauth_credentials.down.sql
@@ -1,2 +1,2 @@
-ALTER TABLE auth.oauth_credentials
+ALTER TABLE annie_auth.oauth_credentials
 DROP COLUMN IF EXISTS anilist_username;

--- a/migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql
+++ b/migrations/20260505000001_add_anilist_username_to_oauth_credentials.up.sql
@@ -1,2 +1,2 @@
-ALTER TABLE auth.oauth_credentials
+ALTER TABLE annie_auth.oauth_credentials
 ADD COLUMN IF NOT EXISTS anilist_username TEXT NULL;

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,7 +152,7 @@ fn init_sentry(
 }
 
 async fn prepare_auth_schema(pool: &sqlx::PgPool) -> Result<()> {
-    sqlx::query("CREATE SCHEMA IF NOT EXISTS auth")
+    sqlx::query("CREATE SCHEMA IF NOT EXISTS annie_auth")
         .execute(pool)
         .await
         .context("Failed to create auth schema")?;
@@ -171,7 +171,7 @@ async fn build_rocket(config: &AppConfig) -> Result<rocket::Rocket<rocket::Build
 
     let migration_options = PgConnectOptions::from_str(&config.database_url)
         .context("Failed to parse database URL")?
-        .options([("search_path", "auth,public")]);
+        .options([("search_path", "annie_auth,public")]);
     let migration_pool = PgPoolOptions::new()
         .max_connections(1)
         .connect_with(migration_options)

--- a/src/main.rs
+++ b/src/main.rs
@@ -155,7 +155,7 @@ async fn prepare_auth_schema(pool: &sqlx::PgPool) -> Result<()> {
     sqlx::query("CREATE SCHEMA IF NOT EXISTS annie_auth")
         .execute(pool)
         .await
-        .context("Failed to create auth schema")?;
+        .context("Failed to create annie_auth schema")?;
 
     Ok(())
 }

--- a/src/utils/functions.rs
+++ b/src/utils/functions.rs
@@ -326,7 +326,7 @@ pub async fn upsert_oauth_credentials(
     }
 
     sqlx::query(
-        "INSERT INTO auth.oauth_credentials \
+        "INSERT INTO annie_auth.oauth_credentials \
          (discord_user_id, anilist_id, anilist_username, access_token, refresh_token, token_expires_at, token_updated_at) \
          VALUES ($1, $2, $3, $4, $5, $6, NOW()) \
          ON CONFLICT (discord_user_id) DO UPDATE SET \
@@ -385,7 +385,7 @@ async fn mark_expired_oauth_credential_relink_required(
     );
 
     sqlx::query(
-        "UPDATE auth.oauth_credentials \
+        "UPDATE annie_auth.oauth_credentials \
          SET relink_required_at = NOW(), relink_reason = $2 \
          WHERE discord_user_id = $1 \
            AND relink_required_at IS NULL \
@@ -424,7 +424,7 @@ pub async fn mark_oauth_credentials_relink_required(
     );
 
     sqlx::query(
-        "UPDATE auth.oauth_credentials \
+        "UPDATE annie_auth.oauth_credentials \
          SET relink_required_at = NOW(), relink_reason = $2 \
          WHERE discord_user_id = $1",
     )
@@ -463,7 +463,7 @@ pub async fn fetch_credential_by_discord_user(
     sqlx::query_as::<_, OAuthCredential>(
         "SELECT discord_user_id, anilist_id, anilist_username, access_token, refresh_token, \
          token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
-         FROM auth.oauth_credentials WHERE discord_user_id = $1",
+         FROM annie_auth.oauth_credentials WHERE discord_user_id = $1",
     )
     .bind(discord_user_id)
     .fetch_optional(db)
@@ -490,7 +490,7 @@ pub async fn fetch_credential_by_anilist_id(
     sqlx::query_as::<_, OAuthCredential>(
         "SELECT discord_user_id, anilist_id, anilist_username, access_token, refresh_token, \
          token_expires_at, token_updated_at, relink_required_at, relink_reason, created_at \
-         FROM auth.oauth_credentials WHERE anilist_id = $1",
+         FROM annie_auth.oauth_credentials WHERE anilist_id = $1",
     )
     .bind(anilist_id)
     .fetch_optional(db)
@@ -657,7 +657,7 @@ pub async fn insert_oauth_session(
     );
 
     sqlx::query(
-        "INSERT INTO auth.oauth_sessions (state, discord_user_id, expires_at) \
+        "INSERT INTO annie_auth.oauth_sessions (state, discord_user_id, expires_at) \
          VALUES ($1, $2, NOW() + ($3 * INTERVAL '1 second'))",
     )
     .bind(state)
@@ -682,7 +682,7 @@ pub async fn consume_oauth_session(
     db: &Pool<Postgres>,
 ) -> Result<OAuthSession, SessionConsumeError> {
     let session = sqlx::query_as::<_, OAuthSession>(
-        "UPDATE auth.oauth_sessions \
+        "UPDATE annie_auth.oauth_sessions \
          SET used_at = NOW() \
          WHERE state = $1 AND used_at IS NULL AND expires_at > NOW() \
          RETURNING state, discord_user_id, expires_at, used_at, created_at",
@@ -702,7 +702,7 @@ pub async fn consume_oauth_session(
     }
 
     let diag =
-        sqlx::query_as::<_, Diag>("SELECT used_at FROM auth.oauth_sessions WHERE state = $1")
+        sqlx::query_as::<_, Diag>("SELECT used_at FROM annie_auth.oauth_sessions WHERE state = $1")
             .bind(state_val)
             .fetch_optional(db)
             .await
@@ -1293,7 +1293,7 @@ mod tests {
     #[sqlx::test(migrations = "./migrations")]
     async fn consume_session_fails_for_expired_state(pool: Pool<Postgres>) {
         sqlx::query(
-            "INSERT INTO auth.oauth_sessions (state, discord_user_id, expires_at) \
+            "INSERT INTO annie_auth.oauth_sessions (state, discord_user_id, expires_at) \
              VALUES ($1, $2, NOW() - INTERVAL '1 minute')",
         )
         .bind("expired_state")


### PR DESCRIPTION
## Summary

Rename the Annie Mei auth-service-owned database schema from `auth` to `annie_auth` to avoid colliding with Supabase's reserved `auth` schema.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [x] Chore

## Changes
- b6b2d2eb0e8aac69f4bf75169b7159e842e9aef3: replace auth-service runtime SQL, migrations, and docs with the `annie_auth` schema name

### Notes

Supabase owns the built-in `auth` schema, so the Railway auth-service deployment could not create/manage that schema. This fix keeps the schema-split design but uses `annie_auth` for Annie Mei OAuth tables and SQLx migration history.

The bot still needs a matching follow-up from `auth.*` to `annie_auth.*`; this PR only fixes the auth-service deployment path.

### High-risk resources

- PostgreSQL schemas: `annie_auth`, `annie_mei`, Supabase-managed `auth`
- Tables: `annie_auth.oauth_credentials`, `annie_auth.oauth_sessions`
- Migration history: `annie_auth._sqlx_migrations`

## Validation
- [x] cargo fmt --check
- [x] cargo test, 60 tests
- [x] cargo clippy --all-targets --all-features -- -D warnings

## References

---

This PR description was written by gpt-5.5.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/annie-mei/auth/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->